### PR TITLE
showing failed field names

### DIFF
--- a/src/main/scala/com/gu/fezziwig/CirceScroogeMacros.scala
+++ b/src/main/scala/com/gu/fezziwig/CirceScroogeMacros.scala
@@ -94,10 +94,10 @@ private class CirceScroogeMacrosImpl(val c: blackbox.Context) {
           *   `scala.reflect.internal.Types$TypeError: value <none> is not a member of com.gu.fezziwig.FezziwigTests`
           */
         val decoderCopy = c.untypecheck(implicitDecoder)
-        val errMsg = s"Unable to find ${name.toString}"
+
         val accDecodeParam =
           q"""cursor.downField(${name.toString}).success
-            .map(x => $decoderCopy.accumulating(x)).getOrElse(_root_.cats.data.Validated.invalidNel(_root_.io.circe.DecodingFailure($errMsg, cursor.history)))"""
+            .map(x => $decoderCopy.accumulating(x)).getOrElse(_root_.cats.data.Validated.invalidNel(_root_.io.circe.DecodingFailure("Unable to find: " + ${name.toString}, cursor.history)))"""
 
         if (param.asTerm.isParamWithDefault) {
           val defaultValue = A.companion.member(TermName("apply$default$" + (i + 1)))
@@ -224,10 +224,10 @@ private class CirceScroogeMacrosImpl(val c: blackbox.Context) {
 
       val accDecExpr = {
         val decoderCopy = c.untypecheck(implicitDecoderForParam)
-        val errMsg = s"Unable to find $paramName"
+
         cq"""$paramName =>
           c.downField($paramName).success.map(x => $decoderCopy.accumulating(x).map($applyMethod))
-            .getOrElse(_root_.cats.data.Validated.invalidNel(_root_.io.circe.DecodingFailure($errMsg, c.history)))"""
+            .getOrElse(_root_.cats.data.Validated.invalidNel(_root_.io.circe.DecodingFailure("Unable to find " + $paramName, c.history)))"""
       }
 
       acc match { case (decs, accDecs) => (decs :+ decExpr, accDecs :+ accDecExpr) }

--- a/src/main/scala/com/gu/fezziwig/CirceScroogeMacros.scala
+++ b/src/main/scala/com/gu/fezziwig/CirceScroogeMacros.scala
@@ -94,10 +94,10 @@ private class CirceScroogeMacrosImpl(val c: blackbox.Context) {
           *   `scala.reflect.internal.Types$TypeError: value <none> is not a member of com.gu.fezziwig.FezziwigTests`
           */
         val decoderCopy = c.untypecheck(implicitDecoder)
-
+        val errMsg = s"Unable to find ${name.toString}"
         val accDecodeParam =
           q"""cursor.downField(${name.toString}).success
-            .map(x => $decoderCopy.accumulating(x)).getOrElse(_root_.cats.data.Validated.invalidNel(_root_.io.circe.DecodingFailure("Attempt to decode value on failed cursor", cursor.history)))"""
+            .map(x => $decoderCopy.accumulating(x)).getOrElse(_root_.cats.data.Validated.invalidNel(_root_.io.circe.DecodingFailure($errMsg, cursor.history)))"""
 
         if (param.asTerm.isParamWithDefault) {
           val defaultValue = A.companion.member(TermName("apply$default$" + (i + 1)))
@@ -224,9 +224,10 @@ private class CirceScroogeMacrosImpl(val c: blackbox.Context) {
 
       val accDecExpr = {
         val decoderCopy = c.untypecheck(implicitDecoderForParam)
+        val errMsg = s"Unable to find $paramName"
         cq"""$paramName =>
           c.downField($paramName).success.map(x => $decoderCopy.accumulating(x).map($applyMethod))
-            .getOrElse(_root_.cats.data.Validated.invalidNel(_root_.io.circe.DecodingFailure("Attempt to decode value on failed cursor", c.history)))"""
+            .getOrElse(_root_.cats.data.Validated.invalidNel(_root_.io.circe.DecodingFailure($errMsg, c.history)))"""
       }
 
       acc match { case (decs, accDecs) => (decs :+ decExpr, accDecs :+ accDecExpr) }


### PR DESCRIPTION
replacing "Attempt to decode a failed cursor" with a more informative error message containing the name of the field which failed