### PR TITLE
Accumulate errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installation
 ------------
 ```
 libraryDependencies ++= Seq(
-  "com.gu" %% "fezziwig" % "0.2.0"
+  "com.gu" %% "fezziwig" % "0.3"
 )
 ```
 
@@ -19,3 +19,10 @@ Usage
 ```
 import com.gu.fezziwig.CirceScroogeMacros._
 ``` 
+
+The generated decoders support accumulation of errors, e.g.
+```
+import com.gu.fezziwig.CirceScroogeMacros._
+val decoder = Decoder[MyThriftStruct]
+val result = decoder.accumulating(json.hcursor)
+```

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -1,36 +1,37 @@
 package com.gu.fezziwig
 
 import org.scalatest.{FlatSpec, Matchers}
-import com.gu.fezziwig.CirceScroogeMacros._
 import gnieh.diffson.circe._
-import io.circe.{Decoder, DecodingFailure, Encoder, Json}
+import io.circe._
 import io.circe.syntax._
 import io.circe.parser._
 import cats.syntax.either._
+import com.gu.fezziwig.CirceScroogeMacros._
 
-class FezziwigTests extends FlatSpec with Matchers {
+class FezziwigTests extends FlatSpec with Matchers  {
+
+  /**
+    * TODO - Currently the macros cannot handle thrift map types. There must be some shapeless magic we can do to fix this.
+    *
+    * Circe provides decodeMapLike and encodeMapLike, meaning we can find implicit Map decoders/encoders from here.
+    * But the macros cannot find them when generating the scrooge decoders/encoders.
+    *
+    * So for now the following two implicits are needed for the test to pass :(
+    */
+  implicit def intMapEncoder = Encoder.instance[scala.collection.Map[String,Seq[Int]]] { s =>
+    val fields = s.toList.map {
+      case (k, v) => k -> Json.fromValues(v.map(_.asJson))
+    }
+    Json.fromFields(fields)
+  }
+
+  implicit def intMapDecoder = Decoder.instance[scala.collection.Map[String,Seq[Int]]] { c =>
+    import cats.syntax.either._
+    val result: Map[String, Seq[Int]] = Map("k" -> Seq(2))  //cheat!
+    Either.right(result)
+  }
 
   it should "round-trip scrooge thrift models" in {
-
-    /**
-      * TODO - Currently the macros cannot handle thrift map types. There must be some shapeless magic we can do to fix this.
-      *
-      * Circe provides decodeMapLike and encodeMapLike, meaning we can find implicit Map decoders/encoders from here.
-      * But the macros cannot find them when generating the scrooge decoders/encoders.
-      *
-      * So for now the following two implicits are needed for the test to pass :(
-      */
-    implicit def intMapEncoder = Encoder.instance[scala.collection.Map[String,Seq[Int]]] { s =>
-      val fields = s.toList.map {
-        case (k, v) => k -> Json.fromValues(v.map(_.asJson))
-      }
-      Json.fromFields(fields)
-    }
-
-    implicit def intMapDecoder = Decoder.instance[scala.collection.Map[String,Seq[Int]]] { c =>
-      val result: Map[String, Seq[Int]] = Map("k" -> Seq(2))  //cheat!
-      Either.right(result)
-    }
 
     val jsonString =
       """
@@ -60,5 +61,36 @@ class FezziwigTests extends FlatSpec with Matchers {
     val diff = JsonDiff.diff(jsonBefore, jsonAfter, false)
     if (diff != JsonPatch(Nil)) println(s"${diff.toString}")
     diff should be(JsonPatch(Nil))
+  }
+
+  it should "accumulate errors" in {
+    //In the following json, the fields 's' and 'foo' have incorrect types
+    val jsonString =
+      """
+        |{
+        |  "b": {
+        |    "u": {
+        |      "c": {
+        |        "s": 1
+        |      }
+        |    }
+        |  },
+        |  "foo": 1,
+        |  "bar": 3,
+        |  "e": "ENUM_A",
+        |  "intMap": {
+        |    "k": [2]
+        |  }
+        |}
+      """.stripMargin
+
+    val dec = Decoder[StructA]
+
+    val jsonBefore: Json = parse(jsonString).toOption.get
+
+    val result = dec.accumulating(jsonBefore.hcursor)
+
+    result.isInvalid should be(true)
+    result.swap.foreach(nel => nel.toList.length should be(2))
   }
 }


### PR DESCRIPTION
Normal circe `Decoder` instances fail-fast. However, it is possible to continue decoding and accumulate the errors if you use an `AccumulatingDecoder`.

Editorial Tools (@fredex42) would like to have this functionality.

The return types differ as follows:
- a `Decoder[A]` returns: `Either[DecodingFailure, A]`
- an `AccumulatingDecoder[A]` returns: `cats.data.ValidatedNel[DecodingFailure, A]`

An `AccumulatingDecoder` can be obtained from a standard `Decoder` by calling its `accumulating` method.
However, if we call this on our current generated thrift `Decoder` instances then the default logic will just convert the resulting `Either` into a `Validated`. So the thrift class' params will still be decoded using standard `Decoder`s, and any nested errors will not be accumulated.

This change overrides the `decodeAccumulating` method on `Decoder`s for `ThriftStruct` and `ThriftUnion` types, to ensure `AccumulatingDecoder`s are used for all nested types.

However, for ThriftStructs with more than [22 parameters](https://github.com/typelevel/cats/blob/155f7f534993c30d6e757de990330ac796dad5da/project/Boilerplate.scala#L44), the default `AccumulatingDecoder` is used.

## Changed behaviour
The previous behaviour for parameters with default values was to use the default if either the field is missing or if the field cannot be decoded. The latter is unlikely to be the desired behaviour - if a field is present then it should decode correctly. This is now the case for both normal and accumulating decoding.

## Testing
Besides the fezziwig tests, I've also tested this locally with content-api-models. After shifting around the implicit definitions for atoms, the compile time is the same.
I also ran the benchmarks.