### PR TITLE
Since commons-lang3 is no longer a part of libthrift starting from 0.…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "fezziwig"
 scalaVersion := "2.11.8"
 organization := "com.gu"
 
-val circeVersion = "0.7.0"
+val circeVersion = "0.8.0"
 
 pomExtra := (
   <url>https://github.com/guardian/fezziwig</url>
@@ -61,8 +61,8 @@ resolvers += Resolver.sonatypeRepo("releases")
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
-  "org.apache.thrift" % "libthrift" % "0.9.1",
-  "com.twitter" %% "scrooge-core" % "4.5.0",
+  "org.apache.thrift" % "libthrift" % "0.9.3",
+  "com.twitter" %% "scrooge-core" % "4.16.0",
   "io.circe" %% "circe-parser" % circeVersion % "test",
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
   "com.github.agourlay" %% "cornichon" % "0.10.4" % "test",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers += "twitter-repo" at "https://maven.twttr.com"
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "4.6.0")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "4.16.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/src/main/scala/com/gu/fezziwig/CirceScroogeMacros.scala
+++ b/src/main/scala/com/gu/fezziwig/CirceScroogeMacros.scala
@@ -155,11 +155,10 @@ private class CirceScroogeMacrosImpl(val c: blackbox.Context) {
     val typeName = A.typeSymbol.name.toString
     val valueOf = A.companion.member(TermName("valueOf"))
     val unknown = A.companion.member(TermName(s"EnumUnknown$typeName"))
-    val pattern = q"""_root_.java.util.regex.Pattern.compile("(-|_)")"""
 
     q"""
       _root_.io.circe.Decoder[String].map(value => {
-        val withoutSeparators = $pattern.matcher(value).replaceAll("");
+        val withoutSeparators = value.filterNot(ch => ch == '_' || ch == '-')
         $valueOf(withoutSeparators).getOrElse($unknown.apply(-1))
       })
     """

--- a/src/main/scala/com/gu/fezziwig/CirceScroogeMacros.scala
+++ b/src/main/scala/com/gu/fezziwig/CirceScroogeMacros.scala
@@ -3,7 +3,7 @@ package com.gu.fezziwig
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 import com.twitter.scrooge.{ThriftEnum, ThriftStruct, ThriftUnion}
-import io.circe.{ Decoder, Encoder}
+import io.circe.{Decoder, Encoder}
 import shapeless.{Lazy, |¬|}
 
 /**
@@ -155,10 +155,11 @@ private class CirceScroogeMacrosImpl(val c: blackbox.Context) {
     val typeName = A.typeSymbol.name.toString
     val valueOf = A.companion.member(TermName("valueOf"))
     val unknown = A.companion.member(TermName(s"EnumUnknown$typeName"))
+    val pattern = q"""_root_.java.util.regex.Pattern.compile("(-|_)")"""
 
     q"""
       _root_.io.circe.Decoder[String].map(value => {
-        val withoutSeparators = _root_.org.apache.commons.lang3.StringUtils.replaceChars(value, "-_", "")
+        val withoutSeparators = $pattern.matcher(value).replaceAll("");
         $valueOf(withoutSeparators).getOrElse($unknown.apply(-1))
       })
     """


### PR DESCRIPTION
Hi there,

Since commons-lang3 is no longer a part of libthrift starting from 0.9.2, StringUtils.replaceChars has been replaced with j.u.r.Pattern. I've also bumped scrooge and circe versions.

Thank you!