### PR TITLE
Verify json value is an object before decoding structs

### DIFF
--- a/src/test/thrift/test.thrift
+++ b/src/test/thrift/test.thrift
@@ -28,4 +28,5 @@ struct StructA {
   3: optional i32 bar
   4: required Enum e
   5: required map<string, list<i32>> intMap
+  7: optional StructC x
 }


### PR DESCRIPTION
Given the thrift definition:
```
struct Inner {
  1: optional string s
}

struct Outer {
  1: required Inner i
}
```

Decoding the following json to an instance of `Outer` should fail:
```
{
  "i": "Why is this a string? It should be an object!"
}
```

However, this will currently decode to the scrooge class as: `Outer(Inner(None))` because `s` is optional.
This is wrong - decoding should fail because `i` should be an object.
Decoders for structs now check it's a json object before decoding.