### PR TITLE
WIP: Stop using deprecated cartesian operator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ import sbt.Keys._
 import sbtrelease.ReleaseStateTransformations._
 
 name := "fezziwig"
-scalaVersion := "2.12.2"
-crossScalaVersions := Seq("2.11.8", scalaVersion.value)
+scalaVersion := "2.12.4"
+crossScalaVersions := Seq("2.11.11", scalaVersion.value)
 organization := "com.gu"
 
 val circeVersion = "0.8.0"

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ scalaVersion := "2.12.4"
 crossScalaVersions := Seq("2.11.11", scalaVersion.value)
 organization := "com.gu"
 
-val circeVersion = "0.8.0"
+val circeVersion = "0.9.0-M2"
 
 pomExtra := (
   <url>https://github.com/guardian/fezziwig</url>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
-sbt.version=0.13.13
+sbt.version=1.0.4
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "twitter-repo" at "https://maven.twttr.com"
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "4.18.0")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "17.11.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.1")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -11,27 +11,6 @@ import io.circe.CursorOp.DownField
 
 class FezziwigTests extends FlatSpec with Matchers  {
 
-  /**
-    * TODO - Currently the macros cannot handle thrift map types. There must be some shapeless magic we can do to fix this.
-    *
-    * Circe provides decodeMapLike and encodeMapLike, meaning we can find implicit Map decoders/encoders from here.
-    * But the macros cannot find them when generating the scrooge decoders/encoders.
-    *
-    * So for now the following two implicits are needed for the test to pass :(
-    */
-  implicit def intMapEncoder = Encoder.instance[scala.collection.Map[String,Seq[Int]]] { s =>
-    val fields = s.toList.map {
-      case (k, v) => k -> Json.fromValues(v.map(_.asJson))
-    }
-    Json.fromFields(fields)
-  }
-
-  implicit def intMapDecoder = Decoder.instance[scala.collection.Map[String,Seq[Int]]] { c =>
-    import cats.syntax.either._
-    val result: Map[String, Seq[Int]] = Map("k" -> Seq(2))  //cheat!
-    Either.right(result)
-  }
-
   it should "round-trip scrooge thrift models" in {
     val jsonString =
       """


### PR DESCRIPTION
This is more a plea for help than a PR (!), but here's where I got to anyway...

We have `-deprecation`, `-Xfatal-warnings` in the Ophan build, so when we pulled in a recent version of Cats we got this fatal compilation error:

```
[error] /home/roberto/guardian/ophan/the-slab/app/extractors/AcquisitionExtractor.scala:11: method |@| in class SemigroupalOps is deprecated: Replaced by an apply syntax, e.g. instead of (a |@| b).map(...) use (a, b).mapN(...)
[error]   private implicit val acquisitionDecoder: Decoder[Acquisition] = decodeThriftStruct[Acquisition]
```

Specifically, that's `method |@| in class SemigroupalOps is deprecated: Replaced by an apply syntax, e.g. instead of (a |@| b).map(...) use (a, b).mapN(...)` - this came in with https://github.com/typelevel/cats/commit/99b543b3a490e14ea219c8c57eb15ffa3d0c6340#diff-a972240fb7094b81ab2706b7ac15cb33

I tried in a very ham-fisted way to update Fezziwig to respect that, but the tests currently fail - let me know if you figure it out, I guess we'll have to switch off `-Xfatal-warnings` in Ophan for the time being.
