### PR TITLE
Fix release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ releaseProcess := Seq(
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  publishArtifacts,
+  releaseStepCommandAndRemaining("publish"),
   setNextVersion,
   commitNextVersion,
   releaseStepCommand("sonatypeReleaseAll"),


### PR DESCRIPTION
Since updating to sbt 1, trying to release caused the following error:
```
[error] java.lang.RuntimeException: Repository for publishing is not specified.
[error] 	at scala.sys.package$.error(package.scala:27)
[error] 	at sbt.Classpaths$.$anonfun$getPublishTo$1(Defaults.scala:2439)
[error] 	at scala.Option.getOrElse(Option.scala:121)
[error] 	at sbt.Classpaths$.getPublishTo(Defaults.scala:2439)
[error] 	at sbtrelease.Compat$.checkPublishTo(Compat.scala:43)
```

This change appears to fix it