### PR TITLE
Bump scrooge core version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "org.apache.thrift" % "libthrift" % "0.9.3",
-  "com.twitter" %% "scrooge-core" % "4.18.0",
+  "com.twitter" %% "scrooge-core" % "4.20.0",
   "io.circe" %% "circe-parser" % circeVersion % "test",
   "org.scalatest" %% "scalatest" % "3.0.3" % "test",
   "com.github.agourlay" %% "cornichon" % "0.10.4" % "test",


### PR DESCRIPTION
To match ophan-event-model, avoiding eviction warning in projects that depend on both