### PR TITLE
Drop support for 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbtrelease.ReleaseStateTransformations._
 
 name := "fezziwig"
 scalaVersion := "2.13.1"
-crossScalaVersions := Seq("2.11.12", "2.12.10", scalaVersion.value)
+crossScalaVersions := Seq("2.12.10", scalaVersion.value)
 organization := "com.gu"
 
 val circeVersion = "0.12.1"


### PR DESCRIPTION
Because Circe doesn't support 2.11 starting from 0.12.