### PR TITLE
Release cross-built builds & don't generate deprecated methods

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import sbt.Keys._
-import sbtrelease.ReleaseStateTransformations._
 
 name := "fezziwig"
 scalaVersion := "2.13.1"
@@ -7,9 +6,6 @@ crossScalaVersions := Seq("2.12.10", scalaVersion.value)
 organization := "com.gu"
 
 val circeVersion = "0.12.1"
-
-publishTo :=
-  Some(if (isSnapshot.value) Opts.resolver.sonatypeSnapshots else Opts.resolver.sonatypeStaging)
 
 publishMavenStyle := true
 publishArtifact in Test := false
@@ -31,7 +27,12 @@ developers := List(
   Developer(id = "annebyrne", name = "Anne Byrne", email = "", url = url("https://github.com/annebyrne"))
 )
 
-releaseProcess := Seq(
+publishTo := sonatypePublishToBundle.value
+
+import ReleaseTransformations._
+
+releaseCrossBuild := true // true if you cross-build the project for multiple Scala versions
+releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
   runClean,
@@ -39,10 +40,11 @@ releaseProcess := Seq(
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  publishArtifacts,
+  // For non cross-build projects, use releaseStepCommand("publishSigned")
+  releaseStepCommandAndRemaining("+publishSigned"),
+  releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
   commitNextVersion,
-  releaseStepCommand("sonatypeRelease"),
   pushChanges
 )
 resolvers += Resolver.sonatypeRepo("releases")
@@ -50,11 +52,11 @@ resolvers += Resolver.sonatypeRepo("releases")
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
-  "org.apache.thrift" % "libthrift" % "0.12.0",
-  "com.twitter" %% "scrooge-core" % "19.9.0",
+  "org.apache.thrift" % "libthrift" % "0.13.0",
+  "com.twitter" %% "scrooge-core" % "19.11.0",
   "io.circe" %% "circe-parser" % circeVersion % "test",
   "org.scalatest" %% "scalatest" % "3.0.8" % "test",
-  "org.gnieh" %% "diffson-circe" % "4.0.0-M5" % "test"
+  "org.gnieh" %% "diffson-circe" % "4.0.0" % "test"
 )
 
 //For tests

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.2.8
+sbt.version=1.3.3
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
-resolvers += "twitter-repo" at "https://maven.twttr.com"
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "19.9.0")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.4")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "19.11.0")
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
+

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -80,7 +80,7 @@ class FezziwigTests extends FlatSpec with Matchers  {
 
     val jsonBefore: Json = parse(jsonString).toOption.get
 
-    val result = dec.accumulating(jsonBefore.hcursor)
+    val result = dec.decodeAccumulating(jsonBefore.hcursor)
 
     result.isInvalid should be(true)
     result.swap.foreach(nel => {


### PR DESCRIPTION
We only released Fezziwig v1.3 to for Scala 2.13!

https://repo1.maven.org/maven2/com/gu/fezziwig_2.13/1.3/

...so I've updated the config to do both. I had to fix the plugins imports as well, as we were missing the sbt-pgp plugin, and my copy of sbt was not able to load the project as defined on master!

### Don't generate deprecated Circe methods

We were seeing a lot of deprecation warnings on compilation as the later versions of Circe deprecate:

* `io.circe.AccumulatingDecoder`
* `io.circe.Decoder.decodeAccumulating()`

...so I'm sneaking fixes for those deprecated methods/types into this PR too.