### PR TITLE
check the scala 2.13 artifact in the readme badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Fezziwig
 ========
 
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/fezziwig_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/fezziwig_2.11) [![Build Status](https://travis-ci.org/guardian/fezziwig.svg?branch=master)](https://travis-ci.org/guardian/fezziwig)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/fezziwig_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/fezziwig_2.13) [![Build Status](https://travis-ci.org/guardian/fezziwig.svg?branch=master)](https://travis-ci.org/guardian/fezziwig)
 
 [Fezziwig](https://en.wikipedia.org/wiki/Mr._Fezziwig) is a library for compile time generation of [Circe](https://github.com/circe/circe) encoders/decoders for [Scrooge](https://twitter.github.io/scrooge/)-generated classes representing [Thrift](http://thrift.apache.org/) objects.
 


### PR DESCRIPTION
It was checking the latest version the scala 2.11 artifact which is no longer produced, I have updated it to 2.13 which is the latest scala version supported.