### PR TITLE
bump versions to keep snyk happy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,14 @@
 import sbt.Keys._
 
 name := "fezziwig"
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.6"
 crossScalaVersions := Seq("2.12.10", scalaVersion.value)
 organization := "com.gu"
 
-val circeVersion = "0.12.1"
+val circeVersion = "0.14.1"
 
 publishMavenStyle := true
-publishArtifact in Test := false
+Test / publishArtifact := false
 pomIncludeRepository := { _ => false }
 releasePublishArtifactsAction := PgpKeys.publishSigned.value
 licenses := Seq("Apache v2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
@@ -52,13 +52,13 @@ resolvers += Resolver.sonatypeRepo("releases")
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
-  "org.apache.thrift" % "libthrift" % "0.13.0",
-  "com.twitter" %% "scrooge-core" % "19.11.0",
+  "org.apache.thrift" % "libthrift" % "0.14.2",
+  "com.twitter" %% "scrooge-core" % "21.8.0",
   "io.circe" %% "circe-parser" % circeVersion % "test",
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
-  "org.gnieh" %% "diffson-circe" % "4.0.0" % "test"
+  "org.scalatest" %% "scalatest" % "3.2.9" % "test",
+  "org.gnieh" %% "diffson-circe" % "4.1.1" % "test"
 )
 
 //For tests
-scroogeThriftSourceFolder in Test := baseDirectory.value / "src/test/thrift"
-unmanagedResourceDirectories in Test += { baseDirectory.value / "src/test/thrift" }
+Test / scroogeThriftSourceFolder := baseDirectory.value / "src/test/thrift"
+Test / unmanagedResourceDirectories += { baseDirectory.value / "src/test/thrift" }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.3.3
+sbt.version=1.5.5
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "19.11.0")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "21.8.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -1,18 +1,18 @@
 package com.gu.fezziwig
 
-import org.scalatest.{FlatSpec, Matchers}
+import com.gu.fezziwig.CirceScroogeMacros._
 import diffson._
 import diffson.circe._
 import diffson.jsonpatch._
 import diffson.jsonpatch.simplediff._
-import io.circe._
-import io.circe.syntax._
-import io.circe.parser._
-import cats.syntax.either._
-import com.gu.fezziwig.CirceScroogeMacros._
 import io.circe.CursorOp.DownField
+import io.circe._
+import io.circe.parser._
+import io.circe.syntax._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class FezziwigTests extends FlatSpec with Matchers  {
+class FezziwigTests extends AnyFlatSpec with Matchers  {
 
   it should "round-trip scrooge thrift models" in {
     val jsonString =

--- a/src/test/thrift/test.thrift
+++ b/src/test/thrift/test.thrift
@@ -8,7 +8,7 @@ struct StructD {
   1: required string s
 }
 
-union Union {
+union Union1 {
   1: StructC c
   2: StructD d
 }
@@ -19,7 +19,7 @@ enum Enum {
 }
 
 struct StructB {
-  1: required Union u
+  1: required Union1 u
 }
 
 struct StructA {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5-SNAPSHOT"
+version in ThisBuild := "1.5"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5"
+version in ThisBuild := "1.6-SNAPSHOT"


### PR DESCRIPTION
There was a snyk issue
```
  ✗ Denial of Service (DoS) [High Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHETHRIFT-1074898] in org.apache.thrift:libthrift@0.13.0
    introduced by com.gu:acquisition-event-producer_2.13@4.0.32-SNAPSHOT > com.gu:fezziwig_2.13@1.4 > org.apache.thrift:libthrift@0.13.0 and 77 other path(s)
  This issue was fixed in versions: 0.14.0
```
I have come in to update that, and also stayed to bump a few other things while I was here!

The tests all seem to still pass.  I do't have access to push to the repo so I have worked in a fork.  Someone else would need to either ship this or add me so I can push it myself.