### PR TITLE
bump versions to keep snyk happy plus readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Fezziwig
 ========
 
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/fezziwig_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/fezziwig_2.13) [![Build Status](https://travis-ci.org/guardian/fezziwig.svg?branch=master)](https://travis-ci.org/guardian/fezziwig)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/fezziwig_2.13/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/fezziwig_2.13) [![Build Status](https://travis-ci.org/guardian/fezziwig.svg?branch=master)](https://travis-ci.org/guardian/fezziwig)
 
 [Fezziwig](https://en.wikipedia.org/wiki/Mr._Fezziwig) is a library for compile time generation of [Circe](https://github.com/circe/circe) encoders/decoders for [Scrooge](https://twitter.github.io/scrooge/)-generated classes representing [Thrift](http://thrift.apache.org/) objects.
 
@@ -10,7 +10,7 @@ Installation
 ------------
 ```
 libraryDependencies ++= Seq(
-  "com.gu" %% "fezziwig" % "0.6"
+  "com.gu" %% "fezziwig" % "0.VERSIONHERE"
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,7 @@ resolvers += Resolver.sonatypeRepo("releases")
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
-  "org.apache.thrift" % "libthrift" % "0.14.2",
+  "org.apache.thrift" % "libthrift" % "0.15.0",
   "com.twitter" %% "scrooge-core" % "21.8.0",
   "io.circe" %% "circe-parser" % circeVersion % "test",
   "org.scalatest" %% "scalatest" % "3.2.9" % "test",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.6"
+version in ThisBuild := "1.7-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.6-SNAPSHOT"
+version in ThisBuild := "1.6"


### PR DESCRIPTION
This PR bumps libthrift to get an updated downstream dependency.  This is needed for subscriptions-frontend.
It will update to 9.0.43 of tomcat.

  ✗ Remote Code Execution (RCE) [High Severity][https://snyk.io/vuln/SNYK-JAVA-ORGAPACHETOMCATEMBED-1080637] in org.apache.tomcat.embed:tomcat-embed-core@8.5.46
    introduced by com.gu:fezziwig_2.12@1.5 > org.apache.thrift:libthrift@0.14.2 > org.apache.tomcat.embed:tomcat-embed-core@8.5.46 and 3 other path(s)
  This issue was fixed in versions: 10.0.2, 9.0.43, 8.5.63, 7.0.108
 