### PR TITLE
Bump sbt to 1.5.7

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.5.5
+sbt.version=1.5.7
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.7-SNAPSHOT"
+ThisBuild / version := "1.8-SNAPSHOT"


### PR DESCRIPTION
## What does this change?

Bumps sbt to 1.5.7 to address log4j vulnerability concerns.

## How can we measure success?

sbt compiles successfully.