### PR TITLE
Sonatype release via GHA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,35 @@
 name: CI
 
-# it's not really possible to test workflows without first having them
-# exist in the default branch (i.e. main).
-
-on: [workflow_dispatch]
+on: [push, workflow_dispatch]
 
 jobs:
-  example:
+  tests:
     runs-on: ubuntu-latest
+
+    # The first two permissions are needed to interact with GitHub's OIDC Token endpoint.
+    # The second set of three permissions are needed to write test results back to GH
+    permissions:
+      id-token: write
+      contents: read
+      issues: read
+      checks: write
+      pull-requests: write
+
     steps:
-      - run: echo example
+      - uses: actions/checkout@v2
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 11
+          cache: sbt
+
+      - name: Run tests
+        run: sbt +test
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()  #runs even if there is a test failure
+        with:
+          files: target/test-reports/*.xml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,5 +3,6 @@ on:
   - workflow_dispatch
 jobs:
   sbt_release:
+    runs-on: ubuntu-latest
     steps:
       - uses: guardian/actions-sbt-release@pmr/wip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
   sbt_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: guardian/actions-sbt-release@v1
+      - uses: guardian/actions-sbt-release@main
         with:
           fetchDepth: 0
           pgpSecret: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,4 +16,6 @@ jobs:
           fetchDepth: 0
           pgpSecret: ${{ secrets.PGP_SECRET }}
           pgpPassphrase: ${{ secrets.PGP_PASSPHRASE }}
+          sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+          sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
           isSnapshot: ${{ inputs.isSnapshot }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,5 @@ on:
   - workflow_dispatch
 jobs:
   sbt_release:
-    runs-on: ubuntu-latest
     steps:
-      - run: 'echo hello world'
+      - uses: guardian/actions-sbt-release@pmr/wip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,12 @@
 name: 'Publish Release'
 on:
-  - workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      isSnapshot:
+        description: is snapshot release
+        required: true
+        default: true
+        type: boolean
 jobs:
   sbt_release:
     runs-on: ubuntu-latest
@@ -10,4 +16,4 @@ jobs:
           fetchDepth: 0
           pgpSecret: ${{ secrets.PGP_SECRET }}
           pgpPassphrase: ${{ secrets.PGP_PASSPHRASE }}
-          # isSnapshot: false
+          isSnapshot: ${{ inputs.isSnapshot }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,4 +8,3 @@ jobs:
       - uses: guardian/actions-sbt-release@pmr/wip
         with:
           fetchDepth: 0
-          isSnapshot: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
   sbt_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: guardian/actions-sbt-release@pmr/wip
+      - uses: guardian/actions-sbt-release@v1
         with:
           fetchDepth: 0
           pgpSecret: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
   sbt_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: guardian/actions-sbt-release@main
+      - uses: guardian/actions-sbt-release@v2
         with:
           fetchDepth: 0
           pgpSecret: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,5 +8,5 @@ jobs:
       - uses: guardian/actions-sbt-release@pmr/wip
         with:
           fetchDepth: 0
-          pgpSecret: "example"
+          pgpSecret: ${{ secrets.PGP_SECRET }}
           # isSnapshot: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,4 +8,4 @@ jobs:
       - uses: guardian/actions-sbt-release@pmr/wip
         with:
           fetchDepth: 0
-          isSnapshot: false
+#          isSnapshot: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,11 @@ on:
         required: true
         default: true
         type: boolean
+      versionOverride:
+        description: Override version (empty means use tags)
+        type: string
+        default: ''
+        required: false
 jobs:
   sbt_release:
     runs-on: ubuntu-latest
@@ -19,3 +24,4 @@ jobs:
           sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
           sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
           isSnapshot: ${{ inputs.isSnapshot }}
+          version: ${{ inputs.versionOverride }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       isSnapshot:
-        description: is snapshot release
+        description: Produce a snapshot release
         required: true
         default: true
         type: boolean

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,4 +8,5 @@ jobs:
       - uses: guardian/actions-sbt-release@pmr/wip
         with:
           fetchDepth: 0
-#          isSnapshot: false
+          pgpSecret: "example"
+          # isSnapshot: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,3 +6,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: guardian/actions-sbt-release@pmr/wip
+        with:
+          fetchDepth: 0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,6 @@ jobs:
     steps:
       - uses: guardian/actions-sbt-release@v2
         with:
-          fetchDepth: 0
           pgpSecret: ${{ secrets.PGP_SECRET }}
           pgpPassphrase: ${{ secrets.PGP_PASSPHRASE }}
           sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,3 +8,4 @@ jobs:
       - uses: guardian/actions-sbt-release@pmr/wip
         with:
           fetchDepth: 0
+          isSnapshot: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,17 +1,7 @@
 name: 'Publish Release'
 on:
-  workflow_dispatch:
-    inputs:
-      isSnapshot:
-        description: Produce a snapshot release
-        required: true
-        default: true
-        type: boolean
-      versionOverride:
-        description: Override version (empty means use tags)
-        type: string
-        default: ''
-        required: false
+  release:
+    types: [published]
 jobs:
   sbt_release:
     runs-on: ubuntu-latest
@@ -23,5 +13,4 @@ jobs:
           pgpPassphrase: ${{ secrets.PGP_PASSPHRASE }}
           sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
           sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
-          isSnapshot: ${{ inputs.isSnapshot }}
-          version: ${{ inputs.versionOverride }}
+          isSnapshot: ${{ github.event.release.prerelease }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,4 +9,5 @@ jobs:
         with:
           fetchDepth: 0
           pgpSecret: ${{ secrets.PGP_SECRET }}
+          pgpPassphrase: ${{ secrets.PGP_PASSPHRASE }}
           # isSnapshot: false

--- a/build.sbt
+++ b/build.sbt
@@ -32,16 +32,29 @@ publishTo := sonatypePublishToBundle.value
 import ReleaseTransformations._
 
 releaseCrossBuild := true // true if you cross-build the project for multiple Scala versions
-releaseProcess := Seq[ReleaseStep](
+
+lazy val commonReleaseProcess = Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
   runClean,
   runTest,
   // For non cross-build projects, use releaseStepCommand("publishSigned")
   releaseStepCommandAndRemaining("+publishSigned"),
+)
+
+lazy val productionReleaseProcess = commonReleaseProcess ++ Seq[ReleaseStep](
   releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion
 )
+
+lazy val snapshotReleaseProcess = commonReleaseProcess
+
+releaseProcess := {
+  sys.props.get("RELEASE_TYPE") match {
+    case Some("production") => productionReleaseProcess
+    case _ => snapshotReleaseProcess
+  }
+}
 
 resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,8 @@ releaseProcess := Seq[ReleaseStep](
   releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion
 )
-resolvers += Resolver.sonatypeRepo("releases")
+
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -37,15 +37,10 @@ releaseProcess := Seq[ReleaseStep](
   inquireVersions,
   runClean,
   runTest,
-  setReleaseVersion,
-  commitReleaseVersion,
-  tagRelease,
   // For non cross-build projects, use releaseStepCommand("publishSigned")
   releaseStepCommandAndRemaining("+publishSigned"),
   releaseStepCommand("sonatypeBundleRelease"),
-  setNextVersion,
-  commitNextVersion,
-  pushChanges
+  setNextVersion
 )
 resolvers += Resolver.sonatypeRepo("releases")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.5.7
+sbt.version=1.9.7
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "21.8.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
-
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This is an attempt to update the release process so that this library is published to Sonatype via Github actions.

In addition to introducing `release.yaml`, which does the above, we are also updating the build dependencies, and adding a regular `ci.yaml` workflow which will run the tests on a push and add the results to the log.

![image](https://github.com/guardian/fezziwig/assets/2242307/b68e68c4-fe4a-459d-bf16-f9b01ac4b93f)

The release process is built on the `guardian/actions-sbt-release` action, which does some version housekeeping and then runs `sbt release`.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Tested on snapshot release by adding a (temporary) `workflow_dispatch` trigger. See the build logs in the Actions tab.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

We should be able to create a release in github, either snapshot or production, and it will be appropriate signed and pushed to Maven.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

This is low risk as it only affects releases, which should be triggered and checked manually (i.e., nothing will happen automatically on merging of this PR, until an actual release is created in github).
