### PR TITLE
fix versioning when calling sbt release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ jobs:
   sbt_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: guardian/actions-sbt-release@main
+      - uses: guardian/actions-sbt-release@v3
         with:
           pgpSecret: ${{ secrets.PGP_SECRET }}
           pgpPassphrase: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ jobs:
   sbt_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: guardian/actions-sbt-release@v2
+      - uses: guardian/actions-sbt-release@main
         with:
           pgpSecret: ${{ secrets.PGP_SECRET }}
           pgpPassphrase: ${{ secrets.PGP_PASSPHRASE }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target/*
 project/target/*
 project/project/target/*
+version.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -40,11 +40,11 @@ lazy val commonReleaseProcess = Seq[ReleaseStep](
   runTest,
   // For non cross-build projects, use releaseStepCommand("publishSigned")
   releaseStepCommandAndRemaining("+publishSigned"),
+  setReleaseVersion,
 )
 
 lazy val productionReleaseProcess = commonReleaseProcess ++ Seq[ReleaseStep](
   releaseStepCommand("sonatypeBundleRelease"),
-  setNextVersion
 )
 
 lazy val snapshotReleaseProcess = commonReleaseProcess

--- a/build.sbt
+++ b/build.sbt
@@ -36,11 +36,11 @@ releaseCrossBuild := true // true if you cross-build the project for multiple Sc
 lazy val commonReleaseProcess = Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
+  setReleaseVersion,
   runClean,
   runTest,
   // For non cross-build projects, use releaseStepCommand("publishSigned")
   releaseStepCommandAndRemaining("+publishSigned"),
-  setReleaseVersion,
 )
 
 lazy val productionReleaseProcess = commonReleaseProcess ++ Seq[ReleaseStep](

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-ThisBuild / version := "1.8-SNAPSHOT"


### PR DESCRIPTION
With PR #41 I had accidentally removed the release step that uses the version passed into the `release` command, and so it was still using the `version.sbt` file.

I have now fix that, removed the `version.sbt` file, and added it to the `.gitignore` (because SBT release will still create it if you run it locally).