### PR TITLE
remove snapshot repository from the build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,8 +56,6 @@ releaseProcess := {
   }
 }
 
-resolvers ++= Resolver.sonatypeOssRepos("snapshots")
-
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,


### PR DESCRIPTION
As it isn't being used.


SBT release doesn't detect any snapshot deps:

```
sbt:fezziwig> show releaseSnapshotDependencies
[info] *
```

I have confirmed that the tests still pass and I successfully released a snapshot release locally.