### PR TITLE
Adopt GHA Scala Library Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,12 @@
-name: 'Publish Release'
+name: Release
+
 on:
-  workflow_dispatch: {}
-  release:
-    types: [published]
+  workflow_dispatch:
+
 jobs:
-  sbt_release:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: guardian/actions-sbt-release@v3
-        with:
-          pgpSecret: ${{ secrets.PGP_SECRET }}
-          pgpPassphrase: ${{ secrets.PGP_PASSPHRASE }}
-          sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
-          sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
-          isSnapshot: ${{ github.event.release.prerelease }}
+  release:
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    permissions: { contents: write, pull-requests: write }
+    secrets:
+      SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
+      PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
-import sbt.Keys._
+import ReleaseTransformations.*
+import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 name := "fezziwig"
 scalaVersion := "2.13.6"
@@ -7,54 +8,23 @@ organization := "com.gu"
 
 val circeVersion = "0.14.1"
 
-publishMavenStyle := true
-Test / publishArtifact := false
-pomIncludeRepository := { _ => false }
-releasePublishArtifactsAction := PgpKeys.publishSigned.value
-licenses := Seq("Apache v2" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
-homepage := Some(url("https://github.com/guardian/fezziwig"))
-scmInfo := Some(
-  ScmInfo(
-    url("https://github.com/guardian/fezziwig"),
-    "scm:git@github.com:guardian/fezziwig.git"
-  )
-)
-developers := List(
-  Developer(id = "tomrf1", name = "Tom Forbes", email = "", url = url("https://github.com/tomrf1")),
-  Developer(id = "cb372", name = "Chris Birchall", email = "", url = url("https://github.com/cb372")),
-  Developer(id = "mchv", name = "Mariot Chauvin", email = "", url = url("https://github.com/mchv")),
-  Developer(id = "LATaylor-guardian", name = "Luke Taylor", email = "", url = url("https://github.com/LATaylor-guardian")),
-  Developer(id = "annebyrne", name = "Anne Byrne", email = "", url = url("https://github.com/annebyrne"))
-)
+licenses := Seq(License.Apache2)
 
-publishTo := sonatypePublishToBundle.value
-
-import ReleaseTransformations._
+releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
 
 releaseCrossBuild := true // true if you cross-build the project for multiple Scala versions
 
-lazy val commonReleaseProcess = Seq[ReleaseStep](
+releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
-  setReleaseVersion,
   runClean,
   runTest,
-  // For non cross-build projects, use releaseStepCommand("publishSigned")
-  releaseStepCommandAndRemaining("+publishSigned"),
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  setNextVersion,
+  commitNextVersion
 )
-
-lazy val productionReleaseProcess = commonReleaseProcess ++ Seq[ReleaseStep](
-  releaseStepCommand("sonatypeBundleRelease"),
-)
-
-lazy val snapshotReleaseProcess = commonReleaseProcess
-
-releaseProcess := {
-  sys.props.get("RELEASE_TYPE") match {
-    case Some("production") => productionReleaseProcess
-    case _ => snapshotReleaseProcess
-  }
-}
 
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "21.8.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+ThisBuild / version := "1.9.1-SNAPSHOT"


### PR DESCRIPTION
Here we're switching from using [`actions-sbt-release`](https://github.com/guardian/actions-sbt-release) to [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow) for publishing releases of this library - see also https://github.com/guardian/actions-sbt-release/pull/1 for details on why we want to make this move.

A fair bit of sbt configuration is deleted or changed - see the [docs on config changes](https://github.com/guardian/gha-scala-library-release-workflow/blob/main/docs/configuration.md) for more information and enjoy the decreased line-count! ✨

![image](https://github.com/guardian/fezziwig/assets/52038/76a1a134-a5e6-4905-9ef9-86d5c3c0a199)

I'd be very happy to pair with anyone who wants to walk through this PR or try out the release process for themselves - please do let me know if you've got any questions!

Once this PR is merged, we should also delete the old [repository secrets](https://github.com/guardian/fezziwig/settings/secrets/actions) :

![image](https://github.com/guardian/fezziwig/assets/52038/f39245f4-cfaf-4f43-bcb0-bdb65bd7f511)

