### PR TITLE
Support recursive structs

### DIFF
--- a/src/main/scala/com/gu/fezziwig/CirceScroogeMacros.scala
+++ b/src/main/scala/com/gu/fezziwig/CirceScroogeMacros.scala
@@ -74,7 +74,6 @@ private class CirceScroogeMacrosImpl(val c: blackbox.Context) {
       val decoder: c.Tree = {
         // If this is a recursive optional field then decode using `this`
         if (tpe.typeSymbol.fullName == "scala.Option" && tpe.typeArgs.headOption.contains(A)) {
-          println(s"recursive type: $name")
           q"io.circe.Decoder.decodeOption[${tpe.typeArgs.head}](this)"
         } else {
           getImplicitDecoder(tpe)
@@ -146,7 +145,7 @@ private class CirceScroogeMacrosImpl(val c: blackbox.Context) {
       }
     }
 
-    val r = q"""{
+    q"""{
       new _root_.io.circe.Decoder[$A] {
         import cats.syntax.apply._
         import cats.syntax.either._
@@ -160,9 +159,6 @@ private class CirceScroogeMacrosImpl(val c: blackbox.Context) {
         ${accumulating.getOrElse(q"")}
       }
     }"""
-    println(r)
-    r
-
   }
 
   /**
@@ -299,17 +295,13 @@ private class CirceScroogeMacrosImpl(val c: blackbox.Context) {
       else q"""_root_.scala.Some(${name.toString} -> $encoder.apply(thrift.${name.toTermName}))"""
     }
 
-    val r =
-      q"""{
-         new _root_.io.circe.Encoder[$A] {
-            def apply(thrift: $A): _root_.io.circe.Json = {
-              _root_.io.circe.Json.fromFields($pairs.flatten)
-            }
+    q"""{
+       new _root_.io.circe.Encoder[$A] {
+          def apply(thrift: $A): _root_.io.circe.Json = {
+            _root_.io.circe.Json.fromFields($pairs.flatten)
           }
-       }"""
-
-    println(r)
-    r
+        }
+     }"""
   }
 
   /**

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -88,4 +88,8 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
       nel.toList should be(expectedFailures)
     })
   }
+
+  it should "handle recursive type without crashing" in {
+    Decoder[RecursiveStruct]
+  }
 }

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -90,6 +90,9 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
   }
 
   it should "handle recursive type without crashing" in {
+    implicit val dec = Decoder[RecursiveStruct]
+    implicit val enc = Encoder[RecursiveStruct]
+
     val jsonString =
       """
         |{

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -89,7 +89,7 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
     })
   }
 
-  it should "handle recursive type without crashing" in {
+  it should "round-trip recursive structs" in {
     implicit val dec = Decoder[RecursiveStruct]
     implicit val enc = Encoder[RecursiveStruct]
 

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -90,6 +90,24 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
   }
 
   it should "handle recursive type without crashing" in {
-    Decoder[RecursiveStruct]
+    val jsonString =
+      """
+        |{
+        |  "foo": "outer-foo",
+        |  "recursiveStruct": {
+        |    "foo": "nested-foo"
+        |  }
+        |}
+      """.stripMargin
+
+    val jsonBefore: Json = parse(jsonString).toOption.get
+
+    val decoded: RecursiveStruct = jsonBefore.as[RecursiveStruct].toOption.get
+
+    val jsonAfter: Json = decoded.asJson
+
+    val diffJ = diff[Json, JsonPatch[Json]](jsonBefore, jsonAfter)
+    if (diffJ != JsonPatch(Nil)) println(s"${diffJ.toString}")
+    diffJ should be(JsonPatch(Nil))
   }
 }

--- a/src/test/thrift/test.thrift
+++ b/src/test/thrift/test.thrift
@@ -30,3 +30,8 @@ struct StructA {
   5: required map<string, list<i32>> intMap
   7: optional StructC x
 }
+
+struct RecursiveStruct {
+    1: required string foo
+    2: optional RecursiveStruct recursiveStruct
+}


### PR DESCRIPTION
Currently recursive structs cause a stack overflow because it infinitly tries to derive the decoder and encoder.
Instead, we need to check if the type of an optional field is the same as the current type, and if so reference the current Decoder/Encoder (i.e. `this`)

_Edit_ - this of course doesn't solve the problem for indirect recursion, which is the more useful case