### PR TITLE
Generate generics instead of decoders with macros

### DIFF
--- a/src/main/scala/com/gu/fezziwig/CirceScroogeMacros.scala
+++ b/src/main/scala/com/gu/fezziwig/CirceScroogeMacros.scala
@@ -2,157 +2,25 @@ package com.gu.fezziwig
 
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
-import com.twitter.scrooge.{ThriftEnum, ThriftStruct, ThriftUnion}
+import com.twitter.scrooge.ThriftEnum
 import io.circe.{Decoder, Encoder}
-import shapeless.{Lazy, |¬|}
 
 /**
   * Macros for Circe encoding/decoding of various Scrooge-generated classes.
   */
 
 object CirceScroogeMacros {
-  type NotUnion[T] = |¬|[ThriftUnion]#λ[T]  //For telling the compiler not to use certain macros for thrift Unions
-
   /**
     * The macro bundle magic happens here.
     * Note - intellij doesn't like the references to methods in an uninstantiated class, but it does compile.
     */
 
-  implicit def decodeThriftStruct[A <: ThriftStruct : NotUnion]: Decoder[A] = macro CirceScroogeMacrosImpl.decodeThriftStruct[A]
   implicit def decodeThriftEnum[A <: ThriftEnum]: Decoder[A] = macro CirceScroogeMacrosImpl.decodeThriftEnum[A]
-  implicit def decodeThriftUnion[A <: ThriftUnion]: Decoder[A] = macro CirceScroogeMacrosImpl.decodeThriftUnion[A]
-
-  implicit def encodeThriftStruct[A <: ThriftStruct : NotUnion]: Encoder[A] = macro CirceScroogeMacrosImpl.encodeThriftStruct[A]
   implicit def encodeThriftEnum[A <: ThriftEnum]: Encoder[A] = macro CirceScroogeMacrosImpl.encodeThriftEnum[A]
-  implicit def encodeThriftUnion[A <: ThriftUnion]: Encoder[A] = macro CirceScroogeMacrosImpl.encodeThriftUnion[A]
 }
 
 private class CirceScroogeMacrosImpl(val c: blackbox.Context) {
   import c.universe._
-
-  /**
-    * Macro to provide custom decoding of Thrift structs using the companion object's `apply` method.
-    *
-    * The macro is needed because Scrooge generates non-sealed traits.
-    *
-    * Scrooge represents
-    *
-    * {{{
-    * struct Foo {
-    *   1: string a
-    *   2: i32 b
-    * }
-    * }}}
-    *
-    * As a trait plus a companion object with a nested `Immutable` class.
-    * Roughly:
-    *
-    * {{{
-    * object Foo {
-    *   def apply(a: String, b: Int) = new Immutable(a, b)
-    *   class Immutable(val a: String, val b: Int) extends Foo
-    * }
-    *
-    * trait Foo {
-    *   def a: String
-    *   def b: Int
-    * }
-    * }}}
-    */
-
-  def decodeThriftStruct[A: c.WeakTypeTag](x: c.Tree): c.Tree = {
-    val A = weakTypeOf[A]
-
-    val apply = getApplyMethod(A)
-
-    val params = apply.paramLists.head.zipWithIndex.map { case (param, i) =>
-      val name = param.name
-      val tpe = param.typeSignature
-      val fresh = c.freshName(name)
-
-      val implicitDecoder: c.Tree = getImplicitDecoder(tpe)
-
-      val decodeExpr = {
-        val decodeParam =
-          q"""cursor.downField(${name.toString}).success
-            .map(x => x.as[$tpe]($implicitDecoder))"""
-
-        if (param.asTerm.isParamWithDefault) {
-          /**
-            * Fallback to param's default value if the JSON field is not present.
-            * If the field is present but fails to decode then it's still an error.
-            * Note: reverse-engineering the name of the default value because it's not easily available in the reflection API.
-            */
-          val defaultValue = A.companion.member(TermName("apply$default$" + (i + 1)))
-          fq"""$fresh <- $decodeParam.getOrElse(_root_.scala.Right($defaultValue))"""
-        } else {
-          fq"""$fresh <- $decodeParam.getOrElse(_root_.scala.Left(_root_.io.circe.DecodingFailure("Missing field: " + ${name.toString}, cursor.history)))"""
-        }
-      }
-
-      val accDecodeExpr = {
-        /**
-          * If we try to use the same tree twice, the compiler may blow up with the following helpful error message:
-          *   `scala.reflect.internal.Types$TypeError: value <none> is not a member of com.gu.fezziwig.FezziwigTests`
-          */
-        val decoderCopy = c.untypecheck(implicitDecoder)
-
-        val accDecodeParam =
-          q"""cursor.downField(${name.toString}).success
-            .map(x => $decoderCopy.decodeAccumulating(x))"""
-
-        if (param.asTerm.isParamWithDefault) {
-          val defaultValue = A.companion.member(TermName("apply$default$" + (i + 1)))
-          q"""$accDecodeParam.getOrElse(_root_.cats.data.Validated.valid[_root_.cats.data.NonEmptyList[_root_.io.circe.DecodingFailure],$tpe]($defaultValue))"""
-        } else {
-          q"""$accDecodeParam.getOrElse(_root_.cats.data.Validated.invalidNel(_root_.io.circe.DecodingFailure("Missing field: " + ${name.toString}, cursor.history)))"""
-        }
-      }
-
-      (fresh, decodeExpr, accDecodeExpr)
-    }
-
-    /**
-      * Accumulate cats Validated results.
-      * This is only supported for structs with <= 22 parameters.
-      */
-    val accumulating: Option[Tree] = {
-      if (params.length <= 22) {
-
-        val validationExpression = params.map(_._3) match {
-          case a :: Nil => q"""$a.map($apply)"""  //Tuple1 is not supported
-          case Nil => q"""$apply"""
-          case exprs => q"""(..$exprs).mapN($apply)"""
-        }
-
-        Some(q"""
-          override def decodeAccumulating(cursor: _root_.io.circe.HCursor): _root_.io.circe.Decoder.AccumulatingResult[$A] = {
-            cursor.value.asObject.map(_ => $validationExpression)
-              .getOrElse(_root_.cats.data.Validated.invalidNel(_root_.io.circe.DecodingFailure("Expected an object", cursor.history)))
-          }
-        """)
-      } else {
-        c.warning(c.enclosingPosition, s"Decoder for ThriftStruct ${A.typeSymbol.name.toString} will not support accumulated errors for nested types because it has more than 22 parameters.")
-        None
-      }
-    }
-
-    q"""{
-      new _root_.io.circe.Decoder[$A] {
-        import cats.syntax.apply._
-        import cats.syntax.either._
-        def apply(cursor: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[$A] = {
-          for (..${
-            fq"""_ <- Either.fromOption(cursor.value.asObject, _root_.io.circe.DecodingFailure("Expected an object", cursor.history))""" +:
-              params.map(_._2)
-          }) yield $apply(..${params.map(_._1)})
-        }
-
-        ${accumulating.getOrElse(q"")}
-      }
-    }"""
-
-  }
 
   /**
     * Scrooge removes underscores from Thrift enum values.
@@ -169,119 +37,6 @@ private class CirceScroogeMacrosImpl(val c: blackbox.Context) {
         $valueOf(withoutSeparators).getOrElse($unknown.apply(-1))
       })
     """
-  }
-
-  /**
-    * Macro to produce Decoders for ThriftUnion types.
-    *
-    * A ThriftUnion, U, has a companion object which defines a case class extending U for each member of the union.
-    * Each case class takes a single parameter, whose type is an alias for the actual type contained by that member.
-    *
-    * E.g. for the following thrift definition:
-    * {{{
-    *   union U {
-    *     1: FooStruct foo
-    *     2: BarStruct bar
-    *   }
-    *
-    *   struct T {
-    *     1: U union
-    *   }
-    * }}}
-    *
-    * We may expect the following JSON:
-    * {{{
-    *   {
-    *     union: {
-    *       foo: {
-    *         ...
-    *       }
-    *     }
-    *   }
-    * }}}
-    *
-    * In the scrooge-generated code, for the member foo of union U, there exists a case class:
-    *   {{{
-    *   case class Foo(foo: FooAlias) extends U
-    *   }}}
-    * where FooAlias aliases FooStruct.
-    * We need to match on the single JSON field and determine which member of the union is present.
-    * So the decoder will contain a case statement for the member foo as follows:
-    *   {{{
-    *   case "foo" => c.downField("foo").flatMap(_.as[FooStruct](decoderForFooStruct).toOption).map(Foo)
-    *   }}}
-    *
-    */
-  def decodeThriftUnion[A: c.WeakTypeTag]: c.Tree = {
-    val A = weakTypeOf[A]
-
-    val memberClasses: Iterable[Symbol] = getUnionMemberClasses(A)
-
-    val decoderCases: (List[Tree],List[Tree]) = memberClasses.toList.foldLeft(List[Tree](), List[Tree]()) { (acc, memberClass) =>
-      val applyMethod = getApplyMethod(memberClass.typeSignature)
-
-      val param: Symbol = applyMethod.paramLists.headOption.flatMap(_.headOption).getOrElse(c.abort(c.enclosingPosition, s"Not a valid union class: could not find the member class' parameter (${A.typeSymbol.fullName})"))
-      val paramType = param.typeSignature.dealias
-      val paramName = param.name.toString
-
-      val implicitDecoderForParam: c.Tree = getImplicitDecoder(paramType)
-
-      val decExpr = {
-        cq"""$paramName =>
-            c.downField($paramName).success.map(_.as[$paramType]($implicitDecoderForParam).map($applyMethod))"""
-      }
-
-      val accDecExpr = {
-        val decoderCopy = c.untypecheck(implicitDecoderForParam)
-
-        cq"""$paramName =>
-          c.downField($paramName).success.map(x => $decoderCopy.decodeAccumulating(x).map($applyMethod))
-            .getOrElse(_root_.cats.data.Validated.invalidNel(_root_.io.circe.DecodingFailure("Unable to find " + $paramName, c.history)))"""
-      }
-
-      acc match { case (decs, accDecs) => (decs :+ decExpr, accDecs :+ accDecExpr) }
-    }
-
-    q"""{
-      new _root_.io.circe.Decoder[$A] {
-        def apply(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.Result[$A] = {
-          val result: Option[_root_.io.circe.Decoder.Result[$A]] = c.keys.getOrElse(Nil).headOption.flatMap {
-            case ..${decoderCases._1 ++ Seq(cq"""_ => _root_.scala.None""")}
-          }
-          result.getOrElse(_root_.scala.util.Left(_root_.io.circe.DecodingFailure("Missing field under union: "+ ${A.typeSymbol.fullName}, c.history)))
-        }
-
-        override def decodeAccumulating(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.AccumulatingResult[$A] = {
-          val result = c.keys.getOrElse(Nil).headOption.map {
-            case ..${decoderCases._2 ++ Seq(cq"""_ => _root_.cats.data.Validated.invalidNel(_root_.io.circe.DecodingFailure("Unknown param in union: "+ ${A.typeSymbol.fullName}, c.history))""")}
-          }
-          result.getOrElse(_root_.cats.data.Validated.invalidNel(_root_.io.circe.DecodingFailure("Missing field under union: "+ ${A.typeSymbol.fullName}, c.history)))
-        }
-      }
-    }"""
-  }
-
-  def encodeThriftStruct[A: c.WeakTypeTag](x: c.Tree): c.Tree = {
-    val A = weakTypeOf[A]
-    val apply = getApplyMethod(A)
-
-    val pairs = apply.paramLists.head.map { param =>
-      val name = param.name
-      /**
-        * We need to ignore any optional fields which are None, because they'll be included in the result as JNulls.
-        */
-      val (tpe, isOption) = param.typeSignature match {
-        case TypeRef(_, sym, ps) if sym == typeOf[Option[_]].typeSymbol => (ps.head, true)
-        case other => (other, false)
-      }
-
-      val implicitEncoder: c.Tree = getImplicitEncoder(tpe)
-
-      if (isOption) q"""thrift.${name.toTermName}.map(${name.toString} -> $implicitEncoder.apply(_))"""
-      else q"""_root_.scala.Some(${name.toString} -> $implicitEncoder.apply(thrift.${name.toTermName}))"""
-    }
-
-    q"""{ _root_.io.circe.Encoder.instance((thrift: $A) => _root_.io.circe.Json.fromFields($pairs.flatten)) }"""
   }
 
   /**
@@ -303,78 +58,5 @@ private class CirceScroogeMacrosImpl(val c: blackbox.Context) {
         case ..${encoderCases ++ Seq(cq"""_ => _root_.io.circe.Json.Null""")}
       }
     """
-  }
-
-  def encodeThriftUnion[A: c.WeakTypeTag]: c.Tree = {
-    val A = weakTypeOf[A]
-
-    val memberClasses: Iterable[Symbol] = getUnionMemberClasses(A)
-
-    val encoderCases: Iterable[Tree] = memberClasses.map { memberClass =>
-      val applyMethod = getApplyMethod(memberClass.typeSignature)
-
-      val param: Symbol = applyMethod.paramLists.headOption.flatMap(_.headOption).getOrElse(c.abort(c.enclosingPosition, s"Not a valid union class: could not find the member class' parameter (${A.typeSymbol.fullName})"))
-      val paramType = param.typeSignature.dealias
-
-      val implicitEncoderForParam: c.Tree = getImplicitEncoder(paramType)
-
-      cq"""data: $memberClass => Json.obj(${param.name.toString} -> $implicitEncoderForParam.apply(data.${param.name.toTermName}))"""
-    }
-
-    q"""
-      _root_.io.circe.Encoder.instance {
-        case ..${encoderCases ++ Seq(cq"""_ => _root_.io.circe.Json.Null""")}
-      }
-    """
-  }
-
-  private def getApplyMethod(tpe: Type): MethodSymbol = {
-    tpe.companion.member(TermName("apply")) match {
-      case symbol if symbol.isMethod && symbol.asMethod.paramLists.size == 1 => symbol.asMethod
-      case _ => c.abort(c.enclosingPosition, "Not a valid Scrooge class: could not find the companion object's apply method")
-    }
-  }
-
-  private def getUnionMemberClasses(unionType: Type): Iterable[Symbol] = {
-    unionType.companion.members.filter { member =>
-      if (member.isClass && member.name.toString != "UnknownUnionField") {
-        member.asClass.baseClasses.contains(unionType.typeSymbol)
-      } else false
-    }
-  }
-
-  private def getImplicitDecoder(tpe: Type): c.Tree = {
-    val decoderForType = appliedType(weakTypeOf[Decoder[_]].typeConstructor, tpe)
-
-    val normalImplicitDecoder = c.inferImplicitValue(decoderForType)
-    if (normalImplicitDecoder.nonEmpty) {
-      // Found an implicit, no need to use Lazy.
-      // We want to avoid Lazy as much as possible, because extracting its `.value` incurs a runtime cost.
-      normalImplicitDecoder
-    } else {
-      // If we couldn't find an implicit, try again with shapeless `Lazy`.
-      // This is to work around a problem with diverging implicits.
-      // If you try to summon an implicit for heavily nested type, e.g. `Decoder[Option[Seq[String]]]` then the compiler sometimes gives up.
-      // Wrapping with `Lazy` fixes this issue.
-      val lazyDecoderForType = appliedType(weakTypeOf[Lazy[_]].typeConstructor, decoderForType)
-      val implicitLazyDecoder = c.inferImplicitValue(lazyDecoderForType)
-      if (implicitLazyDecoder.isEmpty) c.abort(c.enclosingPosition, s"Could not find an implicit Decoder[$tpe] even after resorting to Lazy")
-      // Note: In theory we could use the `implicitLazyDecoder` that we just found, but... for some reason it crashes the compiler :(
-      q"_root_.scala.Predef.implicitly[_root_.shapeless.Lazy[_root_.io.circe.Decoder[$tpe]]].value"
-    }
-  }
-
-  private def getImplicitEncoder(tpe: Type): c.Tree = {
-    val encoderForType = appliedType(weakTypeOf[Encoder[_]].typeConstructor, tpe)
-    val normalImplicitEncoder = c.inferImplicitValue(encoderForType)
-    if (normalImplicitEncoder.nonEmpty) {
-      normalImplicitEncoder
-    } else {
-      val lazyEncoderForType = appliedType(weakTypeOf[Lazy[_]].typeConstructor, encoderForType)
-      val implicitLazyEncoder = c.inferImplicitValue(lazyEncoderForType)
-      if (implicitLazyEncoder.isEmpty) c.abort(c.enclosingPosition, s"Could not find an implicit Encoder[$tpe] even after resorting to Lazy")
-
-      q"_root_.scala.Predef.implicitly[_root_.shapeless.Lazy[_root_.io.circe.Encoder[$tpe]]].value"
-    }
   }
 }

--- a/src/main/scala/com/gu/fezziwig/CirceScroogeWhiteboxMacros.scala
+++ b/src/main/scala/com/gu/fezziwig/CirceScroogeWhiteboxMacros.scala
@@ -265,7 +265,7 @@ private class CirceScroogeWhiteboxMacrosImpl(val c: whitebox.Context) {
       val paramName = TermName(param.name.toString())
       cq"${injectRPattern(i)(pq"_root_.shapeless.Inl(${paramName})")} => ${getApplyMethod(memberClass.typeSignature)}(${paramName})"
     }}
-    val cNilCase = cq"""${injectR(paramsWithClasses.length)(pq"(_: _root_.shapeless.CNil)")} => throw new RuntimeException("Encountered CNil while converting from ReprType")"""
+    val cNilCase = cq"""${injectR(paramsWithClasses.length)(pq"(_)")} => throw new RuntimeException("Encountered CNil value while converting from ReprType")"""
 
     val labelledGeneric = q"""
     new _root_.shapeless.LabelledGeneric[$A] {

--- a/src/main/scala/com/gu/fezziwig/CirceScroogeWhiteboxMacros.scala
+++ b/src/main/scala/com/gu/fezziwig/CirceScroogeWhiteboxMacros.scala
@@ -11,13 +11,13 @@ import shapeless.syntax.singleton._
 
 object CirceScroogeWhiteboxMacros {
   type NotUnion[T] = |¬|[ThriftUnion]#λ[T]  //For telling the compiler not to use certain macros for thrift Unions
-  implicit def thriftStructGeneric[A <: ThriftStruct : NotUnion, R]: LabelledGeneric.Aux[A, R] = macro CirceScroogeWhiteboxMacrosImpl.thriftStructGeneric[A]
+  implicit def thriftStructLabelledGeneric[A <: ThriftStruct : NotUnion, R]: LabelledGeneric.Aux[A, R] = macro CirceScroogeWhiteboxMacrosImpl.thriftStructLabelledGeneric[A]
 
-  implicit def thriftUnionGeneric[A <: ThriftUnion, R]: LabelledGeneric.Aux[A, R] = macro CirceScroogeWhiteboxMacrosImpl.thriftUnionGeneric[A]
+  implicit def thriftUnionLabelledGeneric[A <: ThriftUnion, R]: LabelledGeneric.Aux[A, R] = macro CirceScroogeWhiteboxMacrosImpl.thriftUnionLabelledGeneric[A]
 
   type TFieldRepr = Record.`'name -> String, 'type -> Byte, 'id -> Short`.T
 
-  implicit val tfieldGeneric: LabelledGeneric.Aux[TField, TFieldRepr] = new LabelledGeneric[TField] {
+  implicit val tfieldLabelledGeneric: LabelledGeneric.Aux[TField, TFieldRepr] = new LabelledGeneric[TField] {
     type Repr = TFieldRepr
 
     def to(struct: TField): Repr = {
@@ -124,7 +124,7 @@ private class CirceScroogeWhiteboxMacrosImpl(val c: whitebox.Context) {
     * }
     * }}}
     */
-  def thriftStructGeneric[A: WeakTypeTag](x: Tree): Tree = {
+  def thriftStructLabelledGeneric[A: WeakTypeTag](x: Tree): Tree = {
     val A = weakTypeOf[A]
     val apply = getApplyMethod(A)
     val params = apply.paramLists.head
@@ -194,7 +194,7 @@ private class CirceScroogeWhiteboxMacrosImpl(val c: whitebox.Context) {
 
   /**
     * Provides a LabelledGeneric implicit for Thrift unions, as
-    * [[thriftStructGeneric]] does for structs.
+    * [[thriftStructLabelledGeneric]] does for structs.
     *
     * Given this thrift definition
     *
@@ -241,7 +241,7 @@ private class CirceScroogeWhiteboxMacrosImpl(val c: whitebox.Context) {
     * @note Fully automatic derivation doesn’t work with this macro, so semi-auto
     * derivation is required.
     */
-  def thriftUnionGeneric[A: WeakTypeTag]: Tree = {
+  def thriftUnionLabelledGeneric[A: WeakTypeTag]: Tree = {
     val A = weakTypeOf[A]
     val memberClasses: List[Symbol] = getUnionMemberClasses(A)
     val paramsWithClasses = memberClasses.map(memberClass => {

--- a/src/main/scala/com/gu/fezziwig/CirceScroogeWhiteboxMacros.scala
+++ b/src/main/scala/com/gu/fezziwig/CirceScroogeWhiteboxMacros.scala
@@ -72,6 +72,8 @@ private class CirceScroogeWhiteboxMacrosImpl(val c: whitebox.Context) {
     *
     * {{{
     * import io.circe.generic.semiauto._
+    * import com.gu.fezziwig.CirceScroogeMacros._
+    * import com.gu.fezziwig.CirceScroogeWhiteboxMacros._
     *
     * implicit val outerStructEncoder: Encoder[OuterStruct] = deriveEncoder
     * implicit val outerStructDecoder: Decoder[OuterStruct] = deriveDecoder

--- a/src/main/scala/com/gu/fezziwig/CirceScroogeWhiteboxMacros.scala
+++ b/src/main/scala/com/gu/fezziwig/CirceScroogeWhiteboxMacros.scala
@@ -1,0 +1,301 @@
+package com.gu.fezziwig
+
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+import com.twitter.scrooge.{ThriftStruct, ThriftUnion}
+import shapeless.{|¬|, LabelledGeneric}
+
+object CirceScroogeWhiteboxMacros {
+  type NotUnion[T] = |¬|[ThriftUnion]#λ[T]  //For telling the compiler not to use certain macros for thrift Unions
+  implicit def thriftStructGeneric[A <: ThriftStruct : NotUnion, R]: LabelledGeneric.Aux[A, R] = macro CirceScroogeWhiteboxMacrosImpl.thriftStructGeneric[A]
+
+  implicit def thriftUnionGeneric[A <: ThriftUnion, R]: LabelledGeneric.Aux[A, R] = macro CirceScroogeWhiteboxMacrosImpl.thriftUnionGeneric[A]
+
+}
+
+private class CirceScroogeWhiteboxMacrosImpl(val c: whitebox.Context) {
+  import c.universe._
+
+  /**
+    * Provides a LabelledGeneric implicit for Thrift structs based on the
+    * companion object’s `apply` method.
+    *
+    * Thrift structs are not a standard ADT of sealed traits and case classes,
+    * which means circe’s derivation doesn’t immediately work for them. However,
+    * this implicit enables circe’s semi-auto derivation to work as normal: the
+    * LabelledGeneric implicit converts between the Thrift struct and a hlist
+    * representation that matches what shapeless would generate for a similar
+    * case class, which circe knows how to generate an Encoder/Decoder for.
+    *
+    * @note Fully automatic derivation does not work with this macro, so you
+    * must derive the Encoders/Decoders where they’re needed.
+    *
+    * =Example=
+    *
+    * For example, given this thrift definition
+    *
+    * {{{
+    * struct OuterStruct {
+    *   1: required string foo
+    *   2: optional InnerStruct inner
+    * }
+    * }}}
+    *
+    * the produced implicit is roughly equivalent to:
+    *
+    * {{{
+    * {
+    *   import shapeless.{Witness, labelled, ::, HNil}
+    *
+    *   val fooWitness = Witness(Symbol("foo"))
+    *   val innerWitness = Witness(Symbol("inner"))
+    *   type OuterStructRepr = labelled.FieldType[fooWitness.T, String] :: labelled.FieldType[innerWitness.T, Option[Option[InnerStruct]]] :: HNil
+    *
+    *   new LabelledGeneric[OuterStruct] {
+    *     type Repr = OuterStructRepr
+    *
+    *     def to(struct: OuterStruct): Repr = {
+    *       val foo: labelled.FieldType[fooWitness.T, String] = labelled.field(struct.foo)
+    *       val inner: labelled.FieldType[innerWitness.T, Option[Option[InnerStruct]]] = labelled.field(Some(struct.inner))
+    *       foo :: inner :: HNil
+    *     }
+    *
+    *     def from(hlist: Repr): OuterStruct = hlist match {
+    *       case foo :: inner :: HNil => OuterStruct(foo, inner.getOrElse(None))
+    *     }
+    *   }
+    * }
+    * }}}
+    *
+    * Then in order to get an Encoder/Decoder for OuterStruct, you will need to
+    * use circe’s semiauto derivation for it and sub-structs:
+    *
+    * {{{
+    * import io.circe.generic.semiauto._
+    *
+    * implicit val outerStructEncoder: Encoder[OuterStruct] = deriveEncoder
+    * implicit val outerStructDecoder: Decoder[OuterStruct] = deriveDecoder
+    * implicit val innerStructEncoder: Encoder[InnerStruct] = deriveEncoder
+    * implicit val innerStructDecoder: Decoder[InnerStruct] = deriveDecoder
+    * }}}
+    *
+    * =Scrooge Representation=
+    *
+    * Scrooge represents
+    *
+    * {{{
+    * struct Foo {
+    *   1: string a
+    *   2: i32 b
+    * }
+    * }}}
+    *
+    * As a trait plus a companion object with a nested `Immutable` class.
+    * Roughly:
+    *
+    * {{{
+    * object Foo {
+    *   def apply(a: String, b: Int) = new Immutable(a, b)
+    *   class Immutable(val a: String, val b: Int) extends Foo
+    * }
+    *
+    * trait Foo {
+    *   def a: String
+    *   def b: Int
+    * }
+    * }}}
+    */
+  def thriftStructGeneric[A: WeakTypeTag](x: Tree): Tree = {
+    val A = weakTypeOf[A]
+    val apply = getApplyMethod(A)
+    val params = apply.paramLists.head
+    val fieldNames: List[Tree] = params.zipWithIndex.map{case (p, i) =>
+      if (p.asTerm.isParamWithDefault) {
+        val defaultValue = A.companion.member(TermName("apply$default$" + (i + 1)))
+        q"${TermName(p.name.toString())}.getOrElse(${defaultValue})"
+      } else {
+        q"""${TermName(p.name.toString())}"""
+      }}
+    val witnesses: List[Tree] = params.map(
+      param => {
+        val name = param.name
+        val witnessName = TermName(s"${name.toString()}Witness")
+        val symbolString = name.toString()
+        q"""val ${witnessName} = _root_.shapeless.Witness(_root_.scala.Symbol(${symbolString}))"""
+      }
+    )
+    val reprType: Tree = params.foldRight[Tree](tq"""_root_.shapeless.HNil""") { case (param, acc) =>
+      val witnessName = TermName(s"${param.name}Witness")
+      val fieldType: Tree = if (param.asTerm.isParamWithDefault) {
+        tq"Option[${param.typeSignature}]"
+      } else {
+        q"${param.typeSignature}"
+      }
+      tq"""_root_.shapeless.::[_root_.shapeless.labelled.FieldType[${witnessName}.T, ${fieldType}], $acc]"""
+    }
+    val hlist = params.foldRight[Tree](q"""_root_.shapeless.HNil""") { case (param, acc) =>
+      val paramName = TermName(param.name.toString())
+      q"""_root_.shapeless.::(${paramName}, $acc)"""
+    }
+    // hlistPattern is identical to hlist but with the pq interpolator instead of q
+    val hlistPattern = params.foldRight[Tree](pq"""_root_.shapeless.HNil""") { case (param, acc) =>
+      val paramName = TermName(param.name.toString())
+      pq"""_root_.shapeless.::(${paramName}, $acc)"""
+    }
+    val labelledFields = params.map(param => {
+      val paramName = TermName(param.name.toString())
+      val witnessName = TermName(s"${param.name.toString()}Witness")
+      val (fieldExpr, fieldType): (Tree, Tree) = if (param.asTerm.isParamWithDefault) {
+        (q"_root_.scala.Some(struct.${paramName})", tq"Option[${param.typeSignature}]")
+      } else {
+        (q"struct.${paramName}", q"${param.typeSignature}")
+      }
+      q"""val ${paramName}: _root_.shapeless.labelled.FieldType[${witnessName}.T, ${fieldType}] = _root_.shapeless.labelled.field(${fieldExpr})"""
+      }
+    )
+    val labelledGeneric = q"""
+    new _root_.shapeless.LabelledGeneric[$A] {
+      type Repr = ${reprType}
+
+      def to(struct: $A): Repr = {
+        ..$labelledFields
+        $hlist
+      }
+
+      def from(hlist: Repr): $A = hlist match {
+        case $hlistPattern => $apply(..${fieldNames})
+      }
+    }"""
+    q"""{
+      ..$witnesses
+
+      $labelledGeneric
+    }"""
+  }
+
+  /**
+    * Provides a LabelledGeneric implicit for Thrift unions, as
+    * [[thriftStructGeneric]] does for structs.
+    *
+    * Given this thrift definition
+    *
+    * {{{
+    * union Union1 {
+    *   1: StructC c
+    *   2: StructD d
+    * }
+    * }}}
+    *
+    * the produced implicit will be roughly equivalent to
+    *
+    * {{{
+    * {
+    *   import shapeless.{Witness, :+:, labelled, CNil, Inl, Inr}
+    *
+    *   val dWitness = Witness(Symbol("d"))
+    *   val cWitness = Witness(Symbol("c"))
+    *   type Union1Repr = labelled.FieldType[dWitness.T, StructD] :+: labelled.FieldType[cWitness.T, StructC] :+: CNil
+    *
+    *   new LabelledGeneric[Union1] {
+    *     type Repr = Union1Repr
+    *
+    *     def to(union: Union1): Repr = union match {
+    *       case Union1.D(x) => Inl(labelled.field(x))
+    *       case Union1.C(x) => Inr(Inl(labelled.field(x)))
+    *       case Union1.UnknownUnionField(_) => throw new RuntimeException("Unknown union field")
+    *     }
+    *
+    *     def from(repr: Repr): Union1 = repr match {
+    *       case Inl(d) => Union1.D(d)
+    *       case Inr(Inl(c)) => Union1.C(c)
+    *       case Inr(Inr((_: CNil))) => throw new RuntimeException("Encountered CNil while converting from ReprType")
+    *     }
+    *   }
+    * }
+    * }}}
+    *
+    * @note Fully automatic derivation doesn’t work with this macro, so semi-auto
+    * derivation is required.
+    */
+  def thriftUnionGeneric[A: WeakTypeTag]: Tree = {
+    val A = weakTypeOf[A]
+    val memberClasses: List[Symbol] = getUnionMemberClasses(A)
+    val paramsWithClasses = memberClasses.map(memberClass => {
+      val apply = getApplyMethod(memberClass.typeSignature)
+      val param = apply.paramLists.headOption.flatMap(_.headOption).getOrElse(
+        c.abort(c.enclosingPosition, s"Not a valid union class: could not find the member class' parameter (${A.typeSymbol.fullName})")
+      )
+      (param, memberClass)
+    })
+    val witnesses: List[Tree] = paramsWithClasses.map{
+      case (param, memberClass) => {
+        val name = param.name
+        val witnessName = TermName(s"${name.toString()}Witness")
+        val symbolString = name.toString()
+        q"""val ${witnessName} = _root_.shapeless.Witness(_root_.scala.Symbol(${symbolString}))"""
+      }
+    }
+    val reprType: Tree = paramsWithClasses.foldRight[Tree](tq"""_root_.shapeless.CNil""") { case ((param, _), acc) =>
+      val witnessName = TermName(s"${param.name}Witness")
+      tq"""_root_.shapeless.:+:[_root_.shapeless.labelled.FieldType[${witnessName}.T, ${param.typeSignature.dealias}], $acc]"""
+    }
+    def injectR(n: Int)(t: Tree): Tree = {
+      if (n == 0) {
+        t
+      } else {
+        q"_root_.shapeless.Inr(${injectR(n - 1)(t)})"
+      }
+    }
+    def injectRPattern(n: Int)(t: Tree): Tree = {
+      if (n == 0) {
+        t
+      } else {
+        pq"_root_.shapeless.Inr(${injectR(n - 1)(t)})"
+      }
+    }
+    val toCases = paramsWithClasses.zipWithIndex.map{case ((param, memberClass), i) => {
+      val field = q"_root_.shapeless.Inl(_root_.shapeless.labelled.field(x))"
+      cq"${memberClass.companion}(x) => ${injectR(i)(field)}"
+    }}
+    val unknownUnionFieldCase = cq"""${A.typeSymbol.companion}.UnknownUnionField(_) => throw new _root_.java.lang.RuntimeException("Unknown union field")"""
+
+    val fromCases = paramsWithClasses.zipWithIndex.map{case ((param, memberClass), i) => {
+      val paramName = TermName(param.name.toString())
+      cq"${injectRPattern(i)(pq"_root_.shapeless.Inl(${paramName})")} => ${getApplyMethod(memberClass.typeSignature)}(${paramName})"
+    }}
+    val cNilCase = cq"""${injectR(paramsWithClasses.length)(pq"(_: _root_.shapeless.CNil)")} => throw new RuntimeException("Encountered CNil while converting from ReprType")"""
+
+    val labelledGeneric = q"""
+    new _root_.shapeless.LabelledGeneric[$A] {
+      type Repr = ${reprType}
+
+      def to(union: $A): Repr = union match {
+        case ..${toCases ++ List(unknownUnionFieldCase)}
+      }
+
+      def from(repr: Repr): $A = repr match {
+        case ..${fromCases ++ List(cNilCase)}
+      }
+    }"""
+    q"""{
+      ..$witnesses
+
+      $labelledGeneric
+    }"""
+  }
+
+  private def getApplyMethod(tpe: Type): MethodSymbol = {
+    tpe.companion.member(TermName("apply")) match {
+      case symbol if symbol.isMethod && symbol.asMethod.paramLists.size == 1 => symbol.asMethod
+      case _ => c.abort(c.enclosingPosition, "Not a valid Scrooge class: could not find the companion object's apply method")
+    }
+  }
+
+  private def getUnionMemberClasses(unionType: Type): List[Symbol] = {
+    unionType.companion.members.filter { member =>
+      if (member.isClass && member.name.toString != "UnknownUnionField") {
+        member.asClass.baseClasses.contains(unionType.typeSymbol)
+      } else false
+    }.toList
+  }
+}

--- a/src/main/scala/com/gu/fezziwig/CirceScroogeWhiteboxMacros.scala
+++ b/src/main/scala/com/gu/fezziwig/CirceScroogeWhiteboxMacros.scala
@@ -3,29 +3,10 @@ package com.gu.fezziwig
 import scala.language.experimental.macros
 import scala.reflect.macros.whitebox
 import com.twitter.scrooge.{ThriftStruct, ThriftUnion}
-import shapeless.{|¬|, LabelledGeneric, Lazy}
-import io.circe.{Decoder, Encoder}
-import io.circe.generic.semiauto._
-import io.circe.generic.decoding.DerivedDecoder
-import io.circe.generic.encoding.DerivedAsObjectEncoder
+import shapeless.{|¬|, LabelledGeneric}
 
 object CirceScroogeWhiteboxMacros {
   type NotUnion[T] = |¬|[ThriftUnion]#λ[T]  //For telling the compiler not to use certain macros for thrift Unions
-
-  implicit def thriftStructDecoder[A <: ThriftStruct : NotUnion](implicit
-    derivedDecoder: Lazy[DerivedDecoder[A]]
-  ): Decoder[A] = deriveDecoder[A](derivedDecoder)
-  implicit def thriftStructEncoder[A <: ThriftStruct : NotUnion](implicit
-    derivedEncoder: Lazy[DerivedAsObjectEncoder[A]]
-  ): Encoder[A] = deriveEncoder[A](derivedEncoder)
-
-  implicit def thriftUnionDecoder[A <: ThriftUnion](implicit
-    derivedDecoder: Lazy[DerivedDecoder[A]]
-  ): Decoder[A] = deriveDecoder[A](derivedDecoder)
-  implicit def thriftUnionEncoder[A <: ThriftUnion](implicit
-    derivedEncoder: Lazy[DerivedAsObjectEncoder[A]]
-  ): Encoder[A] = deriveEncoder[A](derivedEncoder)
-
   implicit def thriftStructGeneric[A <: ThriftStruct : NotUnion, R]: LabelledGeneric.Aux[A, R] = macro CirceScroogeWhiteboxMacrosImpl.thriftStructGeneric[A]
 
   implicit def thriftUnionGeneric[A <: ThriftUnion, R]: LabelledGeneric.Aux[A, R] = macro CirceScroogeWhiteboxMacrosImpl.thriftUnionGeneric[A]
@@ -45,6 +26,9 @@ private class CirceScroogeWhiteboxMacrosImpl(val c: whitebox.Context) {
     * LabelledGeneric implicit converts between the Thrift struct and a hlist
     * representation that matches what shapeless would generate for a similar
     * case class, which circe knows how to generate an Encoder/Decoder for.
+    *
+    * @note Fully automatic derivation does not work with this macro, so you
+    * must derive the Encoders/Decoders where they’re needed.
     *
     * =Example=
     *
@@ -81,6 +65,18 @@ private class CirceScroogeWhiteboxMacrosImpl(val c: whitebox.Context) {
     *     }
     *   }
     * }
+    * }}}
+    *
+    * Then in order to get an Encoder/Decoder for OuterStruct, you will need to
+    * use circe’s semiauto derivation for it and sub-structs:
+    *
+    * {{{
+    * import io.circe.generic.semiauto._
+    *
+    * implicit val outerStructEncoder: Encoder[OuterStruct] = deriveEncoder
+    * implicit val outerStructDecoder: Decoder[OuterStruct] = deriveDecoder
+    * implicit val innerStructEncoder: Encoder[InnerStruct] = deriveEncoder
+    * implicit val innerStructDecoder: Decoder[InnerStruct] = deriveDecoder
     * }}}
     *
     * =Scrooge Representation=
@@ -217,6 +213,9 @@ private class CirceScroogeWhiteboxMacrosImpl(val c: whitebox.Context) {
     *   }
     * }
     * }}}
+    *
+    * @note Fully automatic derivation doesn’t work with this macro, so semi-auto
+    * derivation is required.
     */
   def thriftUnionGeneric[A: WeakTypeTag]: Tree = {
     val A = weakTypeOf[A]

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -20,47 +20,6 @@ import org.scalatest.matchers.should.Matchers
 import shapeless._
 
 class FezziwigTests extends AnyFlatSpec with Matchers  {
-  implicit val union1Decoder: Decoder[Union1] = deriveDecoder
-  implicit val union1Encoder: Encoder[Union1] = deriveEncoder
-
-  implicit val structBDecoder: Decoder[StructB] = deriveDecoder
-  implicit val structBEncoder: Encoder[StructB] = deriveEncoder
-
-  implicit val structCDecoder: Decoder[StructC] = deriveDecoder
-  implicit val structCEncoder: Encoder[StructC] = deriveEncoder
-
-  implicit val structDDecoder: Decoder[StructD] = deriveDecoder
-  implicit val structDEncoder: Encoder[StructD] = deriveEncoder
-
-  implicit val structADecoder: Decoder[StructA] = deriveDecoder
-  implicit val structAEncoder: Encoder[StructA] = deriveEncoder
-
-  implicit val recTreeDecoder: Decoder[RecTree] = deriveDecoder
-  implicit val recTreeEncoder: Encoder[RecTree] = deriveEncoder
-
-  implicit val recListDecoder: Decoder[RecList] = deriveDecoder
-  implicit val recListEncoder: Encoder[RecList] = deriveEncoder
-
-  implicit val coRecDecoder: Decoder[CoRec] = deriveDecoder
-  implicit val coRecEncoder: Encoder[CoRec] = deriveEncoder
-
-  implicit val coRec2Decoder: Decoder[CoRec2] = deriveDecoder
-  implicit val coRec2Encoder: Encoder[CoRec2] = deriveEncoder
-
-  implicit val vectorTestDecoder: Decoder[VectorTest] = deriveDecoder
-  implicit val vectorTestEncoder: Encoder[VectorTest] = deriveEncoder
-
-  implicit val blockElementDecoder: Decoder[BlockElement] = deriveDecoder
-  implicit val blockElementEncoder: Encoder[BlockElement] = deriveEncoder
-
-  implicit val listElementFieldsDecoder: Decoder[ListElementFields] = deriveDecoder
-  implicit val listElementFieldsEncoder: Encoder[ListElementFields] = deriveEncoder
-
-  implicit val listItemDecoder: Decoder[ListItem] = deriveDecoder
-  implicit val listItemEncoder: Encoder[ListItem] = deriveEncoder
-
-  implicit val decodeDefaultTestStruct: Decoder[DefaultTestStruct] = deriveDecoder
-
   private def testRoundTrip[T](jsonString: String)(implicit decoder: Decoder[T], encoder: Encoder[T]) = {
     val jsonBefore: Json = parse(jsonString).toOption.get
     val decoded: T = jsonBefore.as[T].toOption.get
@@ -206,7 +165,6 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
   }
 
   it should "follow circe default behavior of serialising optional fields as nulls rather than missing" in {
-    implicit val structWithOptionalEncoder: Encoder[StructWithOptional] = deriveEncoder
     val jsonAfter: Json = StructWithOptional().asJson
     jsonAfter.asObject.flatMap(_("optionalField")).value.isNull should be(true)
   }

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -237,6 +237,12 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
       """.stripMargin)
   }
 
+  it should "round-trip optional fields as missing rather than json null" in {
+    implicit val structWithOptionalDecoder: Decoder[StructWithOptional] = deriveDecoder
+    implicit val structWithOptionalEncoder: Encoder[StructWithOptional] = deriveEncoder
+    testRoundTrip[StructWithOptional]("{}")
+  }
+
   it should "accumulate errors" in {
     //In the following json, the fields 's', 'foo' and 'x' have incorrect types
     val expectedFailures = List(

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -39,6 +39,21 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
   implicit val structADecoder: Decoder[StructA] = deriveDecoder
   implicit val structAEncoder: Encoder[StructA] = deriveEncoder
 
+  implicit val recTreeDecoder: Decoder[RecTree] = deriveDecoder
+  implicit val recTreeEncoder: Encoder[RecTree] = deriveEncoder
+
+  implicit val recListDecoder: Decoder[RecList] = deriveDecoder
+  implicit val recListEncoder: Encoder[RecList] = deriveEncoder
+
+  implicit val coRecDecoder: Decoder[CoRec] = deriveDecoder
+  implicit val coRecEncoder: Encoder[CoRec] = deriveEncoder
+
+  implicit val coRec2Decoder: Decoder[CoRec2] = deriveDecoder
+  implicit val coRec2Encoder: Encoder[CoRec2] = deriveEncoder
+
+  implicit val vectorTestDecoder: Decoder[VectorTest] = deriveDecoder
+  implicit val vectorTestEncoder: Encoder[VectorTest] = deriveEncoder
+
   implicit val decodeDefaultTestStruct: Decoder[DefaultTestStruct] = deriveDecoder
 
   private def testRoundTrip[T](jsonString: String)(implicit decoder: Decoder[T], encoder: Encoder[T]) = {
@@ -49,6 +64,85 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
     diffJ should be(JsonPatch(Nil))
   }
 
+  it should "round-trip recursive tree" in {
+    testRoundTrip[RecTree](
+      """
+        |{
+        |  "children": [
+        |    { "item": 5, "children": [] },
+        |    { "item": 4, "children": [] },
+        |    { "item": 3, "children": [ { "item": 2, "children": [] } ] }
+        |  ],
+        |  "item": 1
+        |}
+        |""".stripMargin)
+  }
+
+  it should "round-trip recursive list" in {
+    testRoundTrip[RecList](
+      """
+        |{
+        |  "item": 1,
+        |  "nextitem": {
+        |    "item": 2,
+        |    "nextitem": {
+        |      "item": 3,
+        |      "nextitem": null
+        |    }
+        |  }
+        |}
+        |""".stripMargin)
+  }
+
+  it should "round-trip co-recursive struct" in {
+    testRoundTrip[CoRec](
+      """
+        |{
+        |  "other": {
+        |    "other": {
+        |      "other": {
+        |        "other": {
+        |          "other": {
+        |            "other": null
+        |          }
+        |        }
+        |      }
+        |    }
+        |  }
+        |}
+        |""".stripMargin)
+  }
+
+  it should "round-trip recursive vector" in {
+    testRoundTrip[VectorTest](
+      """
+        |{
+        |  "lister": [
+        |    {
+        |      "item": 1,
+        |      "nextitem": {
+        |        "item": 2,
+        |        "nextitem": null
+        |      }
+        |    },
+        |    {
+        |      "item": 3,
+        |      "nextitem": {
+        |        "item": 4,
+        |        "nextitem": null
+        |      }
+        |    },
+        |    {
+        |      "item": 5,
+        |      "nextitem": {
+        |        "item": 6,
+        |        "nextitem": null
+        |      }
+        |    }
+        |  ]
+        |}
+        |""".stripMargin)
+  }
 
   it should "round-trip scrooge thrift models [outer]" in {
     testRoundTrip[OuterStruct](

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -41,8 +41,17 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
 
   implicit val decodeDefaultTestStruct: Decoder[DefaultTestStruct] = deriveDecoder
 
+  private def testRoundTrip[T](jsonString: String)(implicit decoder: Decoder[T], encoder: Encoder[T]) = {
+    val jsonBefore: Json = parse(jsonString).toOption.get
+    val decoded: T = jsonBefore.as[T].toOption.get
+    val jsonAfter: Json = decoded.asJson
+    val diffJ = diff[Json, JsonPatch[Json]](jsonBefore, jsonAfter)
+    diffJ should be(JsonPatch(Nil))
+  }
+
+
   it should "round-trip scrooge thrift models [outer]" in {
-    val jsonString =
+    testRoundTrip[OuterStruct](
       """
         |{
         |  "foo" : "hello",
@@ -53,23 +62,11 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
         |    }
         |  }
         |}
-      """.stripMargin
-
-    val jsonBefore: Json = parse(jsonString).toOption.get
-
-    val decoded: StructB = jsonBefore.as[StructB].toOption.get
-    // val decoded: StructB = StructB(Union1.C(StructC("hello")))
-    println(s"Decoded is $decoded")
-
-    val jsonAfter: Json = decoded.asJson
-
-    val diffJ = diff[Json, JsonPatch[Json]](jsonBefore, jsonAfter)
-    if (diffJ != JsonPatch(Nil)) println(s"${diffJ.toString}")
-    diffJ should be(JsonPatch(Nil))
+      """.stripMargin)
   }
 
   it should "round-trip StructB (struct containing a union)" in {
-    val jsonString =
+    testRoundTrip[StructB](
       """
         |{
         |  "u" : {
@@ -78,23 +75,11 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
         |    }
         |  }
         |}
-      """.stripMargin
-
-    val jsonBefore: Json = parse(jsonString).toOption.get
-
-    val decoded: StructB = jsonBefore.as[StructB].toOption.get
-    // val decoded: StructB = StructB(Union1.C(StructC("hello")))
-    println(s"Decoded is $decoded")
-
-    val jsonAfter: Json = decoded.asJson
-
-    val diffJ = diff[Json, JsonPatch[Json]](jsonBefore, jsonAfter)
-    if (diffJ != JsonPatch(Nil)) println(s"${diffJ.toString}")
-    diffJ should be(JsonPatch(Nil))
+      """.stripMargin)
   }
 
   it should "round-trip scrooge thrift models" in {
-    val jsonString =
+    testRoundTrip[StructA](
       """
         |{
         |  "b": {
@@ -114,17 +99,7 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
         |    "s": "x"
         |  }
         |}
-      """.stripMargin
-
-    val jsonBefore: Json = parse(jsonString).toOption.get
-
-    val decoded: StructA = jsonBefore.as[StructA].toOption.get
-
-    val jsonAfter: Json = decoded.asJson
-
-    val diffJ = diff[Json, JsonPatch[Json]](jsonBefore, jsonAfter)
-    if (diffJ != JsonPatch(Nil)) println(s"${diffJ.toString}")
-    diffJ should be(JsonPatch(Nil))
+      """.stripMargin)
   }
 
   it should "accumulate errors" in {

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -1,7 +1,7 @@
 package com.gu.fezziwig
 
 import com.gu.fezziwig.CirceScroogeMacros._
-import com.gu.fezziwig.CirceScroogeWhiteboxMacros.{thriftStructGeneric, thriftUnionGeneric, tfieldGeneric}
+import com.gu.fezziwig.CirceScroogeWhiteboxMacros.{thriftStructLabelledGeneric, thriftUnionLabelledGeneric, tfieldLabelledGeneric}
 import com.twitter.io.Buf
 import com.twitter.scrooge._
 import diffson._

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -54,6 +54,15 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
   implicit val vectorTestDecoder: Decoder[VectorTest] = deriveDecoder
   implicit val vectorTestEncoder: Encoder[VectorTest] = deriveEncoder
 
+  implicit val blockElementDecoder: Decoder[BlockElement] = deriveDecoder
+  implicit val blockElementEncoder: Encoder[BlockElement] = deriveEncoder
+
+  implicit val listElementFieldsDecoder: Decoder[ListElementFields] = deriveDecoder
+  implicit val listElementFieldsEncoder: Encoder[ListElementFields] = deriveEncoder
+
+  implicit val listItemDecoder: Decoder[ListItem] = deriveDecoder
+  implicit val listItemEncoder: Encoder[ListItem] = deriveEncoder
+
   implicit val decodeDefaultTestStruct: Decoder[DefaultTestStruct] = deriveDecoder
 
   private def testRoundTrip[T](jsonString: String)(implicit decoder: Decoder[T], encoder: Encoder[T]) = {
@@ -144,7 +153,7 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
         |""".stripMargin)
   }
 
-  it should "round-trip scrooge thrift models [outer]" in {
+  it should "round-trip scrooge recursive thrift models of the form A->Option[A]->Option[B]" in {
     testRoundTrip[OuterStruct](
       """
         |{
@@ -154,6 +163,38 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
         |      "foo" : "oh",
         |      "inner" : null
         |    }
+        |  }
+        |}
+      """.stripMargin)
+  }
+
+  it should "round-trip scrooge recursive thrift models of the form A->Option[B]->List[C]->List[A]" in {
+    testRoundTrip[BlockElement](
+      """
+        |{
+        |  "listTypeData" : {
+        |    "items" : [
+        |      {
+        |        "elements": [
+        |          {
+        |            "listTypeData": null
+        |          },
+        |          {
+        |            "listTypeData": null
+        |          }
+        |        ]
+        |      },
+        |      {
+        |        "elements": [
+        |          {
+        |            "listTypeData": null
+        |          },
+        |          {
+        |            "listTypeData": null
+        |          }
+        |        ]
+        |      }
+        |    ]
         |  }
         |}
       """.stripMargin)

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -20,6 +20,47 @@ import org.scalatest.matchers.should.Matchers
 import shapeless._
 
 class FezziwigTests extends AnyFlatSpec with Matchers  {
+  implicit val union1Decoder: Decoder[Union1] = deriveDecoder
+  implicit val union1Encoder: Encoder[Union1] = deriveEncoder
+
+  implicit val structBDecoder: Decoder[StructB] = deriveDecoder
+  implicit val structBEncoder: Encoder[StructB] = deriveEncoder
+
+  implicit val structCDecoder: Decoder[StructC] = deriveDecoder
+  implicit val structCEncoder: Encoder[StructC] = deriveEncoder
+
+  implicit val structDDecoder: Decoder[StructD] = deriveDecoder
+  implicit val structDEncoder: Encoder[StructD] = deriveEncoder
+
+  implicit val structADecoder: Decoder[StructA] = deriveDecoder
+  implicit val structAEncoder: Encoder[StructA] = deriveEncoder
+
+  implicit val recTreeDecoder: Decoder[RecTree] = deriveDecoder
+  implicit val recTreeEncoder: Encoder[RecTree] = deriveEncoder
+
+  implicit val recListDecoder: Decoder[RecList] = deriveDecoder
+  implicit val recListEncoder: Encoder[RecList] = deriveEncoder
+
+  implicit val coRecDecoder: Decoder[CoRec] = deriveDecoder
+  implicit val coRecEncoder: Encoder[CoRec] = deriveEncoder
+
+  implicit val coRec2Decoder: Decoder[CoRec2] = deriveDecoder
+  implicit val coRec2Encoder: Encoder[CoRec2] = deriveEncoder
+
+  implicit val vectorTestDecoder: Decoder[VectorTest] = deriveDecoder
+  implicit val vectorTestEncoder: Encoder[VectorTest] = deriveEncoder
+
+  implicit val blockElementDecoder: Decoder[BlockElement] = deriveDecoder
+  implicit val blockElementEncoder: Encoder[BlockElement] = deriveEncoder
+
+  implicit val listElementFieldsDecoder: Decoder[ListElementFields] = deriveDecoder
+  implicit val listElementFieldsEncoder: Encoder[ListElementFields] = deriveEncoder
+
+  implicit val listItemDecoder: Decoder[ListItem] = deriveDecoder
+  implicit val listItemEncoder: Encoder[ListItem] = deriveEncoder
+
+  implicit val decodeDefaultTestStruct: Decoder[DefaultTestStruct] = deriveDecoder
+
   private def testRoundTrip[T](jsonString: String)(implicit decoder: Decoder[T], encoder: Encoder[T]) = {
     val jsonBefore: Json = parse(jsonString).toOption.get
     val decoded: T = jsonBefore.as[T].toOption.get
@@ -165,6 +206,7 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
   }
 
   it should "follow circe default behavior of serialising optional fields as nulls rather than missing" in {
+    implicit val structWithOptionalEncoder: Encoder[StructWithOptional] = deriveEncoder
     val jsonAfter: Json = StructWithOptional().asJson
     jsonAfter.asObject.flatMap(_("optionalField")).value.isNull should be(true)
   }

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -20,11 +20,6 @@ import org.scalatest.matchers.should.Matchers
 import shapeless._
 
 class FezziwigTests extends AnyFlatSpec with Matchers  {
-  implicit val outerStructDecoder: Decoder[OuterStruct] = deriveDecoder
-  implicit val outerStructEncoder: Encoder[OuterStruct] = deriveEncoder
-  implicit val innerStructDecoder: Decoder[InnerStruct] = deriveDecoder
-  implicit val innerStructEncoder: Encoder[InnerStruct] = deriveEncoder
-
   implicit val union1Decoder: Decoder[Union1] = deriveDecoder
   implicit val union1Encoder: Encoder[Union1] = deriveEncoder
 
@@ -149,20 +144,6 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
         |""".stripMargin)
   }
 
-  it should "round-trip scrooge recursive thrift models of the form A->Option[A]->Option[B]" in {
-    testRoundTrip[OuterStruct](
-      """
-        |{
-        |  "foo" : "hello",
-        |  "inner" : {
-        |    "outer" : {
-        |      "foo" : "oh"
-        |    }
-        |  }
-        |}
-      """.stripMargin)
-  }
-
   it should "round-trip scrooge recursive thrift models of the form A->Option[B]->List[C]->List[A]" in {
     testRoundTrip[BlockElement](
       """
@@ -200,7 +181,7 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
       """.stripMargin)
   }
 
-  it should "round-trip scrooge thrift models" in {
+  it should "round-trip StructA (a more nested struct)" in {
     testRoundTrip[StructA](
       """
         |{

--- a/src/test/thrift/test.thrift
+++ b/src/test/thrift/test.thrift
@@ -75,3 +75,15 @@ struct CoRec2 {
 struct VectorTest {
   1: list<RecList> lister;
 }
+
+struct BlockElement {
+  1: optional ListElementFields listTypeData;
+}
+
+struct ListElementFields {
+  1: required list<ListItem> items;
+}
+
+struct ListItem {
+  1: required list<BlockElement> elements = [];
+}

--- a/src/test/thrift/test.thrift
+++ b/src/test/thrift/test.thrift
@@ -40,3 +40,16 @@ struct DefaultTestStruct {
   6: required i32 sixth = 6
   7: required list<i32> seventh
 }
+
+struct OuterStruct {
+    1: required string foo
+    2: optional InnerStruct inner
+}
+
+struct InnerStruct {
+    1: optional OuterStruct outer
+}
+
+struct WithDefault {
+    1: optional i32 something = 42
+}

--- a/src/test/thrift/test.thrift
+++ b/src/test/thrift/test.thrift
@@ -85,5 +85,5 @@ struct ListItem {
 }
 
 struct StructWithOptional {
-  1: optional string s;
+  1: optional string optionalField;
 }

--- a/src/test/thrift/test.thrift
+++ b/src/test/thrift/test.thrift
@@ -53,3 +53,25 @@ struct InnerStruct {
 struct WithDefault {
     1: optional i32 something = 42
 }
+
+struct RecTree {
+  1: list<RecTree> children
+  2: i16 item
+}
+
+struct RecList {
+  1: optional RecList nextitem
+  3: i16 item
+}
+
+struct CoRec {
+  1: CoRec2 other
+}
+
+struct CoRec2 {
+  1: optional CoRec other
+}
+
+struct VectorTest {
+  1: list<RecList> lister;
+}

--- a/src/test/thrift/test.thrift
+++ b/src/test/thrift/test.thrift
@@ -50,10 +50,6 @@ struct InnerStruct {
     1: optional OuterStruct outer
 }
 
-struct WithDefault {
-    1: optional i32 something = 42
-}
-
 struct RecTree {
   1: list<RecTree> children
   2: i16 item
@@ -86,4 +82,8 @@ struct ListElementFields {
 
 struct ListItem {
   1: required list<BlockElement> elements = [];
+}
+
+struct StructWithOptional {
+  1: optional string s;
 }

--- a/src/test/thrift/test.thrift
+++ b/src/test/thrift/test.thrift
@@ -41,15 +41,6 @@ struct DefaultTestStruct {
   7: required list<i32> seventh
 }
 
-struct OuterStruct {
-    1: required string foo
-    2: optional InnerStruct inner
-}
-
-struct InnerStruct {
-    1: optional OuterStruct outer
-}
-
 struct RecTree {
   1: list<RecTree> children
   2: i16 item


### PR DESCRIPTION
This PR replaces the macros which generated circe Encoder and Decoders for scrooge-generated classes for thrift structs and unions with new macros which instead generate shapeless LabelledGeneric values. These values match the values that shapeless would generate for the equivalent case classes (mostly; there are some changes to match the existing behaviour with default values), which allows us to use circe’s semi-auto derivation to get the encoders and decoders.

This has the advantage that we no longer need to maintain as much macro complexity, and we can now create encoders/decoders for recursive struct hierarchies (either direct or indirect).

Hopefully this will also mean we can migrate to scala 3 more easily, as our macros are less complicated and more connected to shapeless, which we hear scala 3 macros are inspired by.

Unfortunately, circe’s fully automatic derivation no longer works with this approach, which means this is a breaking change for consumers of the library.

## Implementation notes

- To get it working I had to use whitebox macros instead of blackbox macros, but unfortunately the existing macros don’t work when they’re whitebox, so I’ve split the new macros into their own file (I can’t see how to have whitebox and blackbox macros in the same file).

  - Whitebox implicit def macros [allow refining of the result type by the macro](https://docs.scala-lang.org/overviews/macros/blackbox-whitebox.html). I.e., the implicit search can begin for a `LabelledGeneric.Aux[Union1, R]` where `R` is completely unconstrained, and once the macro has run the result can be examined to refine this type to `LabelledGeneric.Aux[Union1, Union1Repr]`, where `Union1Repr` is a specific HList type (which implicit search can then find a circe macro for to generate a decoder). 

- To match the existing decoder behaviour, any struct field with a default parameter is allowed to be missing from the json, in which case the default value will be used.
  
- Fezziwig now serialises missing optional values as explicit nulls, rather than missing fields. This changes the contract with consumers of the library, but consumers can use deepDropNullValues to exclude nulls, which matches how circe is used elsewhere.

- I suspect there’s a way to replace these macros altogether with shapeless-style implicits, but I don’t know how yet and this works.


## How to test

This change is pretty thoroughly tested by the repository tests, as we’ve added some while it was worked on.

## How can we measure success?

- Recursive structs can now be used with the library
- Hopefully, migration to scala 3 in the future will be easier

## Have we considered potential risks?

### Semi-auto derivation

I believe the main risk is that semi-auto derivation will be more of a pain for consumers of the library than we anticipate.

I’ve made the necessary changes to content-api-models to work with this PR in [content-api-models PR 239](https://github.com/guardian/content-api-models/pull/239), and I don’t think it’s _too_ bad.

### Compile times

It’s hard to analyse the effect these changes will have on compile times: the generated macros are much smaller for nested structs, but more implicit searching is required, and I think whitebox macros are probably less performant than blackbox macros?

I’ll try to make some measurements for content-api-models!

### Non-isomorphism

I think treating default values the way we do also means that the generated LabelledGeneric is not quite an isomorphism: if you start with a thrift struct with an optional field which has a default value, and convert an instance of that struct where the field’s value is unspecified to the generic representation and back, you will now have a thrift struct where the value is specified and matches the default value.

This may cause undesirable or confusing behaviour if using the generic instance outside of json, for example if using shapeless’ lenses or zippers.