### PR TITLE
Add tests of existing encoder/decoder behaviour

### DIFF
--- a/src/main/scala/com/gu/fezziwig/CirceScroogeMacros.scala
+++ b/src/main/scala/com/gu/fezziwig/CirceScroogeMacros.scala
@@ -248,7 +248,7 @@ private class CirceScroogeMacrosImpl(val c: blackbox.Context) {
           val result: Option[_root_.io.circe.Decoder.Result[$A]] = c.keys.getOrElse(Nil).headOption.flatMap {
             case ..${decoderCases._1 ++ Seq(cq"""_ => _root_.scala.None""")}
           }
-          result.getOrElse(Either.left(_root_.io.circe.DecodingFailure("Missing field under union: "+ ${A.typeSymbol.fullName}, c.history)))
+          result.getOrElse(_root_.scala.util.Left(_root_.io.circe.DecodingFailure("Missing field under union: "+ ${A.typeSymbol.fullName}, c.history)))
         }
 
         override def decodeAccumulating(c: _root_.io.circe.HCursor): _root_.io.circe.Decoder.AccumulatingResult[$A] = {

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -97,7 +97,8 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
         |  "third": 3,
         |  "fourth": 4,
         |  "fifth": 5,
-        |  "sixth": 6
+        |  "sixth": 6,
+        |  "seventh": [1,2]
         |}
       """.stripMargin
 
@@ -105,7 +106,7 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
 
     val decoded: Option[DefaultTestStruct] = jsonBefore.as[DefaultTestStruct].toOption
 
-    decoded shouldBe Some(DefaultTestStruct(None, 2, 3, 4, 5, 6))
+    decoded shouldBe Some(DefaultTestStruct(None, 2, 3, 4, 5, 6, List(1, 2)))
   }
 
   it should "decode a missing optional field with default" in {
@@ -116,7 +117,8 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
         |  "third": 3,
         |  "fourth": 4,
         |  "fifth": 5,
-        |  "sixth": 6
+        |  "sixth": 6,
+        |  "seventh": [1,2]
         |}
       """.stripMargin
 
@@ -124,7 +126,7 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
 
     val decoded: Option[DefaultTestStruct] = jsonBefore.as[DefaultTestStruct].toOption
 
-    decoded shouldBe Some(DefaultTestStruct(Some(1), 2, 3, 4, 5, 6))
+    decoded shouldBe Some(DefaultTestStruct(Some(1), 2, 3, 4, 5, 6, List(1,2)))
   }
 
   it should "fail to decode a missing default-requiredness field without default" in {
@@ -135,7 +137,8 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
         |  "second": 2,
         |  "fourth": 4,
         |  "fifth": 5,
-        |  "sixth": 6
+        |  "sixth": 6,
+        |  "seventh": [1,2]
         |}
       """.stripMargin
 
@@ -154,7 +157,8 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
         |  "second": 2,
         |  "third": 3,
         |  "fifth": 5,
-        |  "sixth": 6
+        |  "sixth": 6,
+        |  "seventh": [1,2]
         |}
       """.stripMargin
 
@@ -162,7 +166,7 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
 
     val decoded: Option[DefaultTestStruct] = jsonBefore.as[DefaultTestStruct].toOption
 
-    decoded shouldBe Some(DefaultTestStruct(Some(1), 2, 3, 4, 5, 6))
+    decoded shouldBe Some(DefaultTestStruct(Some(1), 2, 3, 4, 5, 6, List(1, 2)))
   }
 
   it should "fail to decode a missing required field without default" in {
@@ -173,7 +177,8 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
         |  "second": 2,
         |  "third": 3,
         |  "fourth": 4,
-        |  "sixth": 6
+        |  "sixth": 6,
+        |  "seventh": [1, 2]
         |}
       """.stripMargin
 
@@ -192,7 +197,8 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
         |  "second": 2,
         |  "third": 3,
         |  "fourth": 4,
-        |  "fifth": 5
+        |  "fifth": 5,
+        |  "seventh": [1,2]
         |}
       """.stripMargin
 
@@ -200,6 +206,26 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
 
     val decoded: Option[DefaultTestStruct] = jsonBefore.as[DefaultTestStruct].toOption
 
-    decoded shouldBe Some(DefaultTestStruct(Some(1), 2, 3, 4, 5, 6))
+    decoded shouldBe Some(DefaultTestStruct(Some(1), 2, 3, 4, 5, 6, List(1,2)))
+  }
+
+  it should "decode a missing required list field without default" in {
+    val jsonString =
+      """
+        |{
+        |  "first": 1,
+        |  "second": 2,
+        |  "third": 3,
+        |  "fourth": 4,
+        |  "fifth": 5,
+        |  "sixth": 6
+        |}
+      """.stripMargin
+
+    val jsonBefore: Json = parse(jsonString).toOption.get
+
+    val decoded: Decoder.Result[DefaultTestStruct] = jsonBefore.as[DefaultTestStruct]
+
+    decoded shouldBe Right(DefaultTestStruct(Some(1), 2, 3, 4, 5, 6, List()))
   }
 }

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -1,6 +1,8 @@
 package com.gu.fezziwig
 
 import com.gu.fezziwig.CirceScroogeMacros._
+import com.twitter.io.Buf
+import com.twitter.scrooge._
 import diffson._
 import diffson.circe._
 import diffson.jsonpatch._
@@ -9,6 +11,7 @@ import io.circe.CursorOp.DownField
 import io.circe._
 import io.circe.parser._
 import io.circe.syntax._
+import org.apache.thrift.protocol._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -227,5 +230,10 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
     val decoded: Decoder.Result[DefaultTestStruct] = jsonBefore.as[DefaultTestStruct]
 
     decoded shouldBe Right(DefaultTestStruct(Some(1), 2, 3, 4, 5, 6, List()))
+  }
+
+  it should "encode an UnknownUnionField successfully as null" in {
+    val x = Union1.UnknownUnionField(TFieldBlob(new TField("e", TType.STRUCT, 3), Buf.slowFromHexString("ff1e")))
+    x.asJson should be (Json.Null)
   }
 }

--- a/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
+++ b/src/test/scala/com/gu/fezziwig/FezziwigTests.scala
@@ -88,4 +88,118 @@ class FezziwigTests extends AnyFlatSpec with Matchers  {
       nel.toList should be(expectedFailures)
     })
   }
+
+  it should "decode a missing optional field without default" in {
+    val jsonString =
+      """
+        |{
+        |  "second": 2,
+        |  "third": 3,
+        |  "fourth": 4,
+        |  "fifth": 5,
+        |  "sixth": 6
+        |}
+      """.stripMargin
+
+    val jsonBefore: Json = parse(jsonString).toOption.get
+
+    val decoded: Option[DefaultTestStruct] = jsonBefore.as[DefaultTestStruct].toOption
+
+    decoded shouldBe Some(DefaultTestStruct(None, 2, 3, 4, 5, 6))
+  }
+
+  it should "decode a missing optional field with default" in {
+    val jsonString =
+      """
+        |{
+        |  "first": 1,
+        |  "third": 3,
+        |  "fourth": 4,
+        |  "fifth": 5,
+        |  "sixth": 6
+        |}
+      """.stripMargin
+
+    val jsonBefore: Json = parse(jsonString).toOption.get
+
+    val decoded: Option[DefaultTestStruct] = jsonBefore.as[DefaultTestStruct].toOption
+
+    decoded shouldBe Some(DefaultTestStruct(Some(1), 2, 3, 4, 5, 6))
+  }
+
+  it should "fail to decode a missing default-requiredness field without default" in {
+    val jsonString =
+      """
+        |{
+        |  "first": 1,
+        |  "second": 2,
+        |  "fourth": 4,
+        |  "fifth": 5,
+        |  "sixth": 6
+        |}
+      """.stripMargin
+
+    val jsonBefore: Json = parse(jsonString).toOption.get
+
+    val decoded: Decoder.Result[DefaultTestStruct] = jsonBefore.as[DefaultTestStruct]
+
+    decoded shouldBe Left(DecodingFailure("Missing field: third", List()))
+  }
+
+  it should "decode a missing default-requiredness field with default" in {
+    val jsonString =
+      """
+        |{
+        |  "first": 1,
+        |  "second": 2,
+        |  "third": 3,
+        |  "fifth": 5,
+        |  "sixth": 6
+        |}
+      """.stripMargin
+
+    val jsonBefore: Json = parse(jsonString).toOption.get
+
+    val decoded: Option[DefaultTestStruct] = jsonBefore.as[DefaultTestStruct].toOption
+
+    decoded shouldBe Some(DefaultTestStruct(Some(1), 2, 3, 4, 5, 6))
+  }
+
+  it should "fail to decode a missing required field without default" in {
+    val jsonString =
+      """
+        |{
+        |  "first": 1,
+        |  "second": 2,
+        |  "third": 3,
+        |  "fourth": 4,
+        |  "sixth": 6
+        |}
+      """.stripMargin
+
+    val jsonBefore: Json = parse(jsonString).toOption.get
+
+    val decoded: Decoder.Result[DefaultTestStruct] = jsonBefore.as[DefaultTestStruct]
+
+    decoded shouldBe Left(DecodingFailure("Missing field: fifth", List()))
+  }
+
+  it should "decode a missing required field with default" in {
+    val jsonString =
+      """
+        |{
+        |  "first": 1,
+        |  "second": 2,
+        |  "third": 3,
+        |  "fourth": 4,
+        |  "fifth": 5
+        |}
+      """.stripMargin
+
+    val jsonBefore: Json = parse(jsonString).toOption.get
+
+    val decoded: Option[DefaultTestStruct] = jsonBefore.as[DefaultTestStruct].toOption
+
+    decoded shouldBe Some(DefaultTestStruct(Some(1), 2, 3, 4, 5, 6))
+  }
 }

--- a/src/test/thrift/test.thrift
+++ b/src/test/thrift/test.thrift
@@ -30,3 +30,12 @@ struct StructA {
   5: required map<string, list<i32>> intMap
   7: optional StructC x
 }
+
+struct DefaultTestStruct {
+  1: optional i32 first
+  2: optional i32 second = 2
+  3: i32 third
+  4: i32 fourth = 4
+  5: required i32 fifth
+  6: required i32 sixth = 6
+}

--- a/src/test/thrift/test.thrift
+++ b/src/test/thrift/test.thrift
@@ -38,4 +38,5 @@ struct DefaultTestStruct {
   4: i32 fourth = 4
   5: required i32 fifth
   6: required i32 sixth = 6
+  7: required list<i32> seventh
 }


### PR DESCRIPTION
These tests document the current behaviour of Fezziwig’s derived encoders and decoders with default values for fields of different requirednesses, and for `UnknownUnionField` values. This is useful as I’m currently changing the macros in [PR 48](https://github.com/guardian/fezziwig/pull/48) and would like to be sure that I’m matching the existing behaviour.

I do wonder though: does accepting missing required fields mean this behaviour diverges from thrift’s expectations, and does that matter?

I’ve also fixed a small bug I found in the existing macro.