### PR TITLE
Bump major version (to 2.0.0)

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "1.9.3-SNAPSHOT"
+ThisBuild / version := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
With the recent changes in [pull 48](https://github.com/guardian/fezziwig/pull/48), some existing macros were removed: while I’m not 100% certain, I reckon this breaks binary and source compatibility and should therefore require a major version bump [according to Early SemVer](https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html#early-semver-and-sbt-version-policy).

[This description of binary compatibility](https://docs.scala-lang.org/overviews/core/binary-compatibility-for-library-authors.html#binary-compatibility) says that the compiled bytecode should be able to be used in place of the old without linkage errors (where the compiled bytecode references a name that can’t be resolved at runtime). The old macros are implicits and would usually be used without explicitly referencing them, but could have been explicitly referenced, therefore the change in pull 48 break binary backwards compatibility.

I’m bumping the version manually because the release workflow surprisingly didn’t suggest a major version bump when I made a preview release – it instead suggested a patch version bump.