### PR TITLE
Update readme ahead of version 2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Fezziwig
 [![fezziwig Scala version support](https://index.scala-lang.org/guardian/fezziwig/fezziwig/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/guardian/fezziwig/fezziwig)
 [![Release](https://github.com/guardian/fezziwig/actions/workflows/release.yml/badge.svg)](https://github.com/guardian/fezziwig/actions/workflows/release.yml)
 
-[Fezziwig](https://en.wikipedia.org/wiki/Mr._Fezziwig) is a library for compile time generation of [Circe](https://github.com/circe/circe) encoders/decoders for [Scrooge](https://twitter.github.io/scrooge/)-generated classes representing [Thrift](http://thrift.apache.org/) objects.
+Fezziwig, named for [the character from A Christmas Carol](https://en.wikipedia.org/wiki/Mr._Fezziwig), is a library for compile time generation of [Circe](https://github.com/circe/circe) encoders/decoders for [Scrooge](https://twitter.github.io/scrooge/)-generated classes representing [Thrift](http://thrift.apache.org/) objects.
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -8,21 +8,29 @@ Fezziwig
 
 Installation
 ------------
+
 ```
 libraryDependencies ++= Seq(
-  "com.gu" %% "fezziwig" % "0.VERSIONHERE"
+  "com.gu" %% "fezziwig" % "2.0.0"
 )
 ```
 
 Usage
 -----
+
+To use the library, import the macros and use [circe’s semiauto derivation](https://circe.github.io/circe/codecs/semiauto-derivation.html). ([Automatic derivation](https://circe.github.io/circe/codecs/auto-derivation.html) is no longer supported, as of v2.0.0.)
+
 ```
+import io.circe.generic.semiauto.__
 import com.gu.fezziwig.CirceScroogeMacros._
+import com.gu.fezziwig.CirceScroogeWhiteboxMacros._
+
+implicit val exampleStructEncoder: Encoder[ExampleStruct] = deriveEncoder
+implicit val exampleStructDecoder: Decoder[ExampleStruct] = deriveDecoder
 ```
 
 The generated decoders support accumulation of errors, e.g.
+
 ```
-import com.gu.fezziwig.CirceScroogeMacros._
-val decoder = Decoder[MyThriftStruct]
-val result = decoder.accumulating(json.hcursor)
+val result = exampleStructDecoder.accumulating(json.hcursor)
 ```


### PR DESCRIPTION
# Changes

## Update usage instructions

The usage has changed with [pull 48](https://github.com/guardian/fezziwig/pull/48), so this commit updates the usage instructions to match.

## Clarify destination of link explaining etymology

I hadn’t realised from the rendered markdown that this link explained the name! I guess I had assumed it was a link to the project website and dismissed that as something I didn’t need to look at.

Whatever the reason, I think this is clearer.