### PR TITLE
Update scala to 2.13.14 to enable Scala Steward

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import ReleaseTransformations.*
 import sbtversionpolicy.withsbtrelease.ReleaseVersion
 
 name := "fezziwig"
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.14"
 crossScalaVersions := Seq("2.12.10", scalaVersion.value)
 organization := "com.gu"
 


### PR DESCRIPTION
## What does this change?

I’d like to enable [Scala Steward](https://github.com/guardian/scala-steward) on this repository, to help us keep on top of dependency updates. According to [Running Scala Steward on a repo at the Guardian](https://github.com/guardian/maintaining-scala-projects/issues/7), this requires scala version 2.13.11 or greater. I’ve chosen 2.13.14 here because it’s the newest version available.

## How to test

Since it’s just a patch version update of scala, I think it should be fine to depend on the automated tests. If we wanted to be really careful we could make a preview release of the library and test it with a consumer on 2.13, e.g. content-api-models.

## How can we measure success?

Scala Steward should work on the repository, helping us keep up to date with our dependencies.