### PR TITLE
Explicitly install java and sbt in workflow

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -10,7 +10,16 @@ jobs:
     steps:
       - name: Checkout branch
         id: checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Install Java
+        id: java
+        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.2.0
+        with:
+          distribution: corretto
+          java-version: 21
+      - name: Install sbt
+        id: sbt
+        uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
       - name: Submit dependencies
         id: submit
         uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0


### PR DESCRIPTION
## What does this change?

This dependency graph workflow [recently failed](https://github.com/guardian/fezziwig/actions/runs/15353009283/job/43205605234) because it couldn’t find sbt. This happens because it runs on ubuntu-latest, which was updated to a new image some time since the previous run, which new image doesn’t include sbt by default.

Our usual approach to fix this is to explicitly install sbt in workflows, using either sbt/setup-sbt or guardian/setup-scala. In this case I’ve copied the workflow from https://github.com/guardian/cql/pull/48, which was raised 2 days ago by the gu-dependency-graph-integrator bot (and therefore should represent how we currently like to install these things in this workflow).

This adds the necessary use of sbt/setup-sbt, and also adds actions/setup-java and updates actions/checkout.

## How to test

- run the dependency graph submission workflow on this branch (e.g. by adding a trigger for this branch or manually dispatching if possible)
- confirm it runs successfully

## How can we measure success?

- no more build failure on main
- up-to-date dependency info in dependabot

## Have we considered potential risks?

Unlikely to be any: we’re restricting the actions to specific commits, which are already used across our repositories.

- https://github.com/search?q=org%3Aguardian%20b36c23c0d998641eff861008f374ee103c25ac73&type=code
- https://github.com/search?q=org%3Aguardian%208a071aa780c993c7a204c785d04d3e8eb64ef272&type=code
- https://github.com/search?q=org%3Aguardian%20eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871&type=code