### PR TITLE
Fix releaseVersion value for release workflow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val circeVersion = "0.14.10"
 
 licenses := Seq(License.Apache2)
 
-releaseVersion := ReleaseVersion.fromAggregatedAssessedCompatibilityWithLatestRelease().value
+releaseVersion := ReleaseVersion.fromAssessedCompatibilityWithLatestRelease().value
 
 releaseCrossBuild := true // true if you cross-build the project for multiple Scala versions
 


### PR DESCRIPTION
## What does this change?

As described in [this github issue](https://github.com/guardian/gha-scala-library-release-workflow/issues/81), the correct value to use for releaseVersion is fromAssessedCompatibilityWithLatestRelease for single-project apps like this. Using the incorrect value can cause the version checking part of the release workflow to underestimate the version bump needed.

## How to test

No testing required, I reckon!